### PR TITLE
MultiMap + Supernode persistable Map implementations

### DIFF
--- a/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/MapLike.scala
+++ b/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/MapLike.scala
@@ -12,9 +12,11 @@ trait MapLike[K, V] {
 
   def remove(key: K): Option[V]
 
-  def removeAndForget(key: K): Unit
+  def removeAndForget(key: K): Boolean
 
-  def removeOrFail(key: K): Try[Unit]
+  def removeAndForgetOrFail(key: K): Try[Unit]
+
+  def removeOrFail(key: K): Try[V]
 
   def removeAllOrFail(keys: Iterable[K]): Try[Unit]
 
@@ -46,13 +48,13 @@ trait MapLike[K, V] {
 
   def put(key: K, value: V): Option[V]
 
-  def putAndForget(key: K, value: V): Unit
+  def putAndForget(key: K, value: V): Boolean
 
-  def putAllOrFail(keys: IterableOnce[(K, V)]): Try[Unit]
-  
   def putIfAbsent(key: K, value: V): Option[V]
 
   def putIfAbsentOrFail(key: K, value: V): Try[Unit]
+
+  def putAllNewOrFail(entries: IterableOnce[(K, V)]): Try[Unit]
 
   def putIfAbsentAndForget(key: K, value: V): Unit
 
@@ -64,7 +66,5 @@ trait MapLike[K, V] {
 
   def removeOrUpdateOrFail(k: K)(f: V => Option[V]): Try[Unit]
 
-  def adjust(k: K)(f: Option[V] => V): Option[V]
-
-  def adjustAndForget(k: K)(f: Option[V] => V): Unit
+  def adjustAndForget(k: K)(f: Option[V] => V): Boolean
 }

--- a/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/MultiMapLike.scala
+++ b/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/MultiMapLike.scala
@@ -1,0 +1,20 @@
+package org.ergoplatform.uexplorer.mvstore
+
+import scala.util.Try
+
+trait MultiMapLike[PK, C[_, _], K, V] {
+
+  def get(key: PK): Option[C[K, V]]
+
+  def remove(key: PK): Boolean
+
+  def removeOrFail(key: PK): Try[C[K, V]]
+
+  def removeAllOrFail(k: PK, secondaryKeys: IterableOnce[K])(f: C[K, V] => Option[C[K, V]]): Try[Unit]
+
+  def isEmpty: Boolean
+
+  def size: Int
+
+  def adjustAndForget(key: PK, entries: IterableOnce[(K, V)])(f: Option[C[K, V]] => C[K, V]): Try[_]
+}

--- a/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/MultiMvMap.scala
+++ b/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/MultiMvMap.scala
@@ -1,0 +1,41 @@
+package org.ergoplatform.uexplorer.mvstore
+
+import org.ergoplatform.uexplorer.Address
+import org.h2.mvstore.MVMap.DecisionMaker
+import org.h2.mvstore.{MVMap, MVStore}
+
+import scala.collection.concurrent
+import java.util.Map.Entry
+import java.util.concurrent.{ConcurrentHashMap, ConcurrentMap}
+import java.util.stream.Collectors
+import scala.jdk.CollectionConverters.*
+import scala.util.{Failure, Success, Try}
+
+//TODO make SuperNodePCol
+class MultiMvMap[PK, C[_, _], K, V](
+  commonMap: MapLike[PK, C[K, V]],
+  superNodeMap: SuperNodeMapLike[PK, C, K, V]
+) extends MultiMapLike[PK, C, K, V] {
+
+  def get(key: PK): Option[C[K, V]] =
+    superNodeMap.get(key).orElse(commonMap.get(key))
+
+  def remove(key: PK): Boolean =
+    superNodeMap.remove(key).isDefined || commonMap.removeAndForget(key)
+
+  def removeOrFail(key: PK): Try[C[K, V]] =
+    superNodeMap
+      .remove(key)
+      .fold(commonMap.removeOrFail(key))(Success(_))
+
+  def isEmpty: Boolean = superNodeMap.isEmpty && commonMap.isEmpty
+
+  def size: Int = superNodeMap.size + commonMap.size
+
+  def removeAllOrFail(k: PK, secondaryKeys: IterableOnce[K])(f: C[K, V] => Option[C[K, V]]): Try[Unit] =
+    superNodeMap.removeAllOrFail(k, secondaryKeys).fold(commonMap.removeOrUpdateOrFail(k)(f))(identity)
+
+  def adjustAndForget(key: PK, entries: IterableOnce[(K, V)])(f: Option[C[K, V]] => C[K, V]): Try[_] =
+    superNodeMap.putAllNewOrFail(key, entries).getOrElse(Try(commonMap.adjustAndForget(key)(f)))
+
+}

--- a/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/SuperNodeCodec.scala
+++ b/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/SuperNodeCodec.scala
@@ -1,0 +1,37 @@
+package org.ergoplatform.uexplorer.mvstore
+
+import org.h2.mvstore.MVMap
+
+import java.util
+import java.util.Map.Entry
+import java.util.stream.Collectors
+
+trait SuperNodeCodec[SV[_, _], K, V] {
+
+  def read(key: K, m: MVMap[K, V]): Option[V]
+
+  def readAll(m: MVMap[K, V]): SV[K, V]
+
+  def write(to: MVMap[K, V], key: K, value: V): Boolean
+
+  def writeAll(to: MVMap[K, V], from: IterableOnce[(K, V)]): Option[(K, V)]
+
+}
+
+object SuperNodeCodec {
+  implicit def javaHashMapSuperNodeCodec[SK, SV]: SuperNodeCodec[java.util.Map, SK, SV] =
+    new SuperNodeCodec[java.util.Map, SK, SV] {
+      override def readAll(m: MVMap[SK, SV]): util.Map[SK, SV] =
+        m
+          .entrySet()
+          .stream()
+          .collect(Collectors.toMap((e: Entry[SK, SV]) => e.getKey, (e: Entry[SK, SV]) => e.getValue))
+
+      override def writeAll(to: MVMap[SK, SV], from: IterableOnce[(SK, SV)]): Option[(SK, SV)] =
+        from.iterator.find(v => !write(to, v._1, v._2))
+
+      override def read(key: SK, m: MVMap[SK, SV]): Option[SV] = Option(m.get(key))
+
+      override def write(to: MVMap[SK, SV], key: SK, value: SV): Boolean = to.put(key, value) == null
+    }
+}

--- a/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/SuperNodeMapLike.scala
+++ b/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/SuperNodeMapLike.scala
@@ -1,0 +1,21 @@
+package org.ergoplatform.uexplorer.mvstore
+
+import scala.util.Try
+
+trait SuperNodeMapLike[SK, SV[_, _], K, V] {
+
+  def get(key: SK): Option[SV[K, V]]
+
+  def putOnlyNew(key: SK, secondaryKey: K, value: V): Option[Boolean]
+
+  def putAllNewOrFail(sk: SK, entries: IterableOnce[(K, V)]): Option[Try[Unit]]
+
+  def remove(sk: SK): Option[SV[K, V]]
+
+  def removeAllOrFail(sk: SK, values: IterableOnce[K]): Option[Try[Unit]]
+
+  def isEmpty: Boolean
+
+  def size: Int
+
+}

--- a/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/SuperNodeMvMap.scala
+++ b/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/SuperNodeMvMap.scala
@@ -1,0 +1,85 @@
+package org.ergoplatform.uexplorer.mvstore
+
+import com.typesafe.scalalogging.LazyLogging
+import org.ergoplatform.uexplorer.{Address, BoxId, Value}
+import org.h2.mvstore.{MVMap, MVStore}
+
+import java.util.Map.Entry
+import scala.jdk.CollectionConverters.*
+import java.util.concurrent.ConcurrentHashMap
+import java.util.stream.Collectors
+import scala.collection.concurrent
+import scala.util.{Failure, Success, Try}
+
+class SuperNodeMvMap[SK, SV[_, _], K, V](
+  superNodeNameByKey: Map[SK, String],
+  store: MVStore
+)(implicit codec: SuperNodeCodec[SV, K, V])
+  extends SuperNodeMapLike[SK, SV, K, V]
+  with LazyLogging {
+
+  private val supernodeByKey: concurrent.Map[SK, MVMap[K, V]] = new ConcurrentHashMap().asScala
+
+  def get(sk: SK): Option[SV[K, V]] =
+    supernodeByKey.get(sk).map(codec.readAll)
+
+  def putOnlyNew(sk: SK, k: K, v: V): Option[Boolean] =
+    superNodeNameByKey
+      .get(sk)
+      .map { superNodeName =>
+        supernodeByKey.get(sk) match {
+          case None =>
+            logger.info(s"Creating new supernode map $superNodeName")
+            codec.write(store.openMap[K, V](superNodeName), k, v)
+          case Some(m) =>
+            codec.write(m, k, v)
+        }
+      }
+
+  def putAllNewOrFail(sk: SK, entries: IterableOnce[(K, V)]): Option[Try[Unit]] =
+    superNodeNameByKey
+      .get(sk)
+      .map { superNodeName =>
+        val replacedValueOpt =
+          supernodeByKey.get(sk) match {
+            case None =>
+              logger.info(s"Creating new supernode map $superNodeName")
+              val newSuperNodeMap = store.openMap[K, V](superNodeName)
+              supernodeByKey.putIfAbsent(sk, newSuperNodeMap)
+              codec.writeAll(newSuperNodeMap, entries)
+            case Some(m) =>
+              codec.writeAll(m, entries)
+          }
+        replacedValueOpt
+          .map(e => Failure(new AssertionError(s"Key ${e._1} was already present!")))
+          .getOrElse(Success(()))
+      }
+
+  def remove(sk: SK): Option[SV[K, V]] =
+    superNodeNameByKey
+      .get(sk)
+      .flatMap { superNodeName =>
+        supernodeByKey.remove(sk).map { mvMapToRemove =>
+          logger.info(s"Clearing supernode map $superNodeName")
+          val result = codec.readAll(mvMapToRemove)
+          mvMapToRemove.clear()
+          result
+        }
+      }
+
+  def removeAllOrFail(sk: SK, values: IterableOnce[K]): Option[Try[Unit]] =
+    superNodeNameByKey
+      .get(sk)
+      .flatMap { _ =>
+        supernodeByKey.get(sk).map { mvMap =>
+          values.iterator.find(v => mvMap.remove(v) == null).fold(Success(())) { key =>
+            Failure(new AssertionError(s"Removing non-existing key $key"))
+          }
+        }
+      }
+
+  def isEmpty: Boolean = supernodeByKey.forall(_._2.isEmpty)
+
+  def size: Int = supernodeByKey.iterator.map(_._2.size()).sum
+
+}

--- a/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/kryo/KryoSerialization.scala
+++ b/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/kryo/KryoSerialization.scala
@@ -22,24 +22,6 @@ object KryoSerialization {
     implicit val valueByBoxCodec: DbCodec[java.util.Map[BoxId, Value]] = ValueByBoxCodec
     implicit val blockMetadataCodec: DbCodec[BlockInfo]                = BlockInfoCodec
     implicit val addressCodec: DbCodec[Address]                        = AddressCodec
-
-    def javaSetOf[T](e: T): java.util.Set[T] = {
-      val set = new java.util.HashSet[T]()
-      set.add(e)
-      set
-    }
-    def javaMapOf[K, V](k: K, v: V): java.util.Map[K, V] = {
-      val map = new java.util.HashMap[K, V]()
-      map.put(k, v)
-      map
-    }
-    def javaMapOf[K, V](kvs: IterableOnce[(K, V)]): java.util.Map[K, V] = {
-      val map = new java.util.HashMap[K, V]()
-      kvs.iterator.foreach { case (k, v) =>
-        map.put(k, v)
-      }
-      map
-    }
   }
 
   val pool: Pool[Kryo] = new Pool[Kryo](true, false, 8) {

--- a/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/package.scala
+++ b/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/package.scala
@@ -1,0 +1,24 @@
+package org.ergoplatform.uexplorer
+
+package object mvstore {
+
+  def javaSetOf[T](e: T): java.util.Set[T] = {
+    val set = new java.util.HashSet[T]()
+    set.add(e)
+    set
+  }
+
+  def javaMapOf[K, V](k: K, v: V): java.util.Map[K, V] = {
+    val map = new java.util.HashMap[K, V]()
+    map.put(k, v)
+    map
+  }
+
+  def javaMapOf[K, V](kvs: IterableOnce[(K, V)]): java.util.Map[K, V] = {
+    val map = new java.util.HashMap[K, V]()
+    kvs.iterator.foreach { case (k, v) =>
+      map.put(k, v)
+    }
+    map
+  }
+}


### PR DESCRIPTION
FeeContract addresses, miner-fee addresses, etc... cannot be persisted as common addresses as they can grow to millions of boxes. this implementation seamlessly handles supernode addresses as separate persistable Maps so that indexing these addresses does not affect performance.