### PR TITLE
parallelize MvStore reads and writes by Maps

### DIFF
--- a/modules/cassandra/src/main/scala/org/ergoplatform/uexplorer/cassandra/api/Backend.scala
+++ b/modules/cassandra/src/main/scala/org/ergoplatform/uexplorer/cassandra/api/Backend.scala
@@ -24,7 +24,7 @@ trait Backend {
 
   def isEmpty: Boolean
 
-  def removeBlocksFromMainChain(blockIds: Iterable[BlockId]): Future[Done]
+  def removeBlocksFromMainChain(blockIds: Iterable[BlockId]): Try[Done]
 
   def blockWriteFlow: Flow[BestBlockInserted, BestBlockInserted, NotUsed]
 
@@ -61,13 +61,13 @@ class InMemoryBackend extends Backend {
 
   override def close(): Future[Unit] = Future.successful(())
 
-  override def removeBlocksFromMainChain(blockIds: Iterable[BlockId]): Future[Done] =
-    Future(blockIds.foreach(blocksById.remove)).map(_ => Done)
+  override def removeBlocksFromMainChain(blockIds: Iterable[BlockId]): Try[Done] =
+    Try(blockIds.foreach(blocksById.remove)).map(_ => Done)
 
   override def blockWriteFlow: Flow[BestBlockInserted, BestBlockInserted, NotUsed] =
     Flow[BestBlockInserted].map { blockInserted =>
-      blocksByHeight.put(blockInserted.lightBlock.info.height, blockInserted.lightBlock.info)
-      blocksById.put(blockInserted.lightBlock.b.header.id, blockInserted.lightBlock.info)
+      blocksByHeight.put(blockInserted.blockWithInputs.info.height, blockInserted.blockWithInputs.info)
+      blocksById.put(blockInserted.blockWithInputs.b.header.id, blockInserted.blockWithInputs.info)
       blockInserted
     }
 

--- a/modules/chain-indexer/src/main/scala/org/ergoplatform/uexplorer/indexer/Application.scala
+++ b/modules/chain-indexer/src/main/scala/org/ergoplatform/uexplorer/indexer/Application.scala
@@ -9,6 +9,7 @@ import akka.stream.{KillSwitches, SharedKillSwitch}
 import akka.stream.scaladsl.{Flow, Sink, Source}
 import akka.{Done, NotUsed}
 import com.typesafe.scalalogging.{LazyLogging, StrictLogging}
+import org.ergoplatform.ErgoAddressEncoder
 import org.ergoplatform.uexplorer.cassandra.{AkkaStreamSupport, CassandraBackend}
 import org.ergoplatform.uexplorer.indexer.mempool.MempoolStateHolder.*
 import org.ergoplatform.uexplorer.indexer.mempool.{MempoolStateHolder, MempoolSyncer}
@@ -47,6 +48,7 @@ object Application extends App with AkkaStreamSupport with LazyLogging {
         Behaviors.setup[Nothing] { implicit ctx =>
           implicit val system: ActorSystem[Nothing] = ctx.system
           implicit val protocol: ProtocolSettings   = conf.protocol
+          implicit val enc: ErgoAddressEncoder      = protocol.addressEncoder
           implicit val mempoolStateHolderRef: ActorRef[MempoolStateHolderRequest] =
             ctx.spawn(MempoolStateHolder.behavior(MempoolState.empty), "MempoolStateHolder")
 

--- a/modules/chain-indexer/src/main/scala/org/ergoplatform/uexplorer/indexer/config/ChainIndexerConf.scala
+++ b/modules/chain-indexer/src/main/scala/org/ergoplatform/uexplorer/indexer/config/ChainIndexerConf.scala
@@ -22,18 +22,12 @@ import org.ergoplatform.uexplorer.http.LocalNodeUriMagnet
 import org.ergoplatform.uexplorer.cassandra.api.Backend.BackendType
 import org.ergoplatform.uexplorer.janusgraph.api.GraphBackend.GraphBackendType
 import org.ergoplatform.uexplorer.storage.MvStorage.*
+import org.ergoplatform.uexplorer.storage.MvStoreConf
 
 import scala.concurrent.duration.FiniteDuration
 
-case class MvStore(
-  cacheSize: CacheSize,
-  maxIndexingCompactTime: MaxCompactTime,
-  maxIdleCompactTime: MaxCompactTime,
-  heightCompactRate: HeightCompactRate
-)
-
 case class ChainIndexerConf(
-  mvStore: MvStore,
+  mvStore: MvStoreConf,
   nodeAddressToInitFrom: Uri,
   peerAddressToPollFrom: Uri,
   backendType: BackendType,

--- a/modules/explorer-core/src/main/scala/org/ergoplatform/uexplorer/Storage.scala
+++ b/modules/explorer-core/src/main/scala/org/ergoplatform/uexplorer/Storage.scala
@@ -9,8 +9,6 @@ import scala.util.Try
 
 trait Storage {
 
-  def writeReport: Try[_]
-
   def isEmpty: Boolean
 
   def containsBlock(blockId: BlockId, atHeight: Height): Boolean

--- a/modules/explorer-core/src/main/scala/org/ergoplatform/uexplorer/db/Insertable.scala
+++ b/modules/explorer-core/src/main/scala/org/ergoplatform/uexplorer/db/Insertable.scala
@@ -4,6 +4,6 @@ import org.ergoplatform.uexplorer.BlockId
 
 sealed trait Insertable
 
-case class BestBlockInserted(lightBlock: BlockWithInputs, fullBlockOpt: Option[FullBlock]) extends Insertable
+case class BestBlockInserted(blockWithInputs: BlockWithInputs, fullBlockOpt: Option[FullBlock]) extends Insertable
 
 case class ForkInserted(newFork: List[BestBlockInserted], supersededFork: Map[BlockId, BlockInfo]) extends Insertable

--- a/modules/storage/src/main/scala/org/ergoplatform/uexplorer/storage/MvStorage.scala
+++ b/modules/storage/src/main/scala/org/ergoplatform/uexplorer/storage/MvStorage.scala
@@ -10,13 +10,13 @@ import org.ergoplatform.uexplorer.*
 import org.ergoplatform.uexplorer.Const.Protocol.{Emission, FeeContract, Foundation}
 import org.ergoplatform.uexplorer.mvstore.*
 import MvStorage.*
-
 import org.ergoplatform.uexplorer.db.*
 import org.ergoplatform.uexplorer.mvstore.MultiMapLike.MultiMapSize
 import org.ergoplatform.uexplorer.storage.Implicits.*
 import org.ergoplatform.uexplorer.node.{ApiFullBlock, ApiTransaction}
 import org.h2.mvstore.{MVMap, MVStore}
 import org.ergoplatform.uexplorer.db.OutputRecord
+
 import java.io.{BufferedInputStream, File}
 import java.nio.ByteBuffer
 import java.nio.file.{CopyOption, Files, Paths}
@@ -32,6 +32,7 @@ import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
 import scala.io.Source
 import scala.jdk.CollectionConverters.*
 import scala.util.{Failure, Random, Success, Try}
@@ -53,98 +54,106 @@ case class MvStorage(
 
   def rollbackTo(version: Revision): Try[Unit] = Try(store.rollbackTo(version))
 
-  private def removeInputBoxesByErgoTree(ergoTree: ErgoTreeHex, inputBoxes: mutable.Map[BoxId, Value]): Try[_] =
-    ergoTreeHexByUtxo.removeAllOrFail(inputBoxes.keys).flatMap { _ =>
-      utxosByErgoTreeHex.removeAllOrFail(ergoTree, inputBoxes.iterator.map(_._1), inputBoxes.size) { existingBoxIds =>
-        inputBoxes.iterator.map(_._1).foreach(existingBoxIds.remove)
-        Option(existingBoxIds).collect { case m if !m.isEmpty => m }
-      }
-    }
-
-  private def removeInputBoxesByErgoTreeT8(
-    ergoTreeT8: ErgoTreeT8Hex,
-    inputBoxes: mutable.Set[BoxId]
-  ): Try[_] =
-    utxosByErgoTreeT8Hex.removeAllOrFail(ergoTreeT8, inputBoxes, inputBoxes.size) { existingBoxIds =>
-      inputBoxes.foreach(existingBoxIds.remove)
-      Option(existingBoxIds).collect { case m if !m.isEmpty => m }
-    }
-
-  private def persistErgoTreeUtxos(ergoTreeHex: ErgoTreeHex, boxes: Iterable[OutputRecord]): Try[_] =
-    ergoTreeHexByUtxo.putAllNewOrFail(boxes.iterator.map(b => b.boxId -> b.ergoTreeHex)).flatMap { _ =>
-      utxosByErgoTreeHex.adjustAndForget(ergoTreeHex, boxes.iterator.map(b => b.boxId -> b.value), boxes.size)
-    }
-
-  private def persistErgoTreeTemplateUtxos(ergoTreeT8Hex: ErgoTreeT8Hex, boxes: ArraySeq[OutputRecord]): Try[_] =
-    utxosByErgoTreeT8Hex.adjustAndForget(
-      ergoTreeT8Hex,
-      boxes.iterator.map(b => b.boxId -> b.creationHeight),
-      boxes.size
-    )
-
-  def persistNewBlock(b: BlockWithInputs): Try[BlockWithInputs] = {
-    val outErgoTreeFailureOpt =
-      b.outputRecords
-        .groupBy(_.ergoTreeHex)
-        .map { case (ergoTree, boxes) =>
-          persistErgoTreeUtxos(ergoTree, boxes)
-        }
-        .collectFirst { case f @ Failure(_) => f }
-
-    val outErgoTreeT8FailureOpt =
-      b.outputRecords
-        .filter(_.ergoTreeT8Hex.isDefined)
-        .groupBy(_.ergoTreeT8Hex)
-        .collect { case (Some(ergoTreeTemplate), boxes) =>
-          persistErgoTreeTemplateUtxos(ergoTreeTemplate, boxes)
-        }
-        .collectFirst { case f @ Failure(_) => f }
-
-    val inErgoTreeFailureOpt =
-      b.inputRecords.byErgoTree.iterator
-        .map { case (ergoTree, inputIds) =>
-          removeInputBoxesByErgoTree(
-            ergoTree,
-            inputIds.filter { case (boxId, _) =>
-              boxId != Emission.inputBox && boxId != Foundation.inputBox
-            }
-          )
-        }
-        .collectFirst { case f @ Failure(_) => f }
-
-    val inErgoTreeT8FailureOpt =
-      b.inputRecords.byErgoTreeT8.iterator
-        .map { case (ergoTreeT8, inputIds) =>
-          removeInputBoxesByErgoTreeT8(
-            ergoTreeT8,
-            inputIds.filter(boxId => boxId != Emission.inputBox && boxId != Foundation.inputBox)
-          )
-        }
-        .collectFirst { case f @ Failure(_) => f }
-
-    blockById
-      .putIfAbsentOrFail(b.b.header.id, b.info.persistable(store.getCurrentVersion))
-      .flatMap { _ =>
-        blockIdsByHeight.adjust(b.info.height)(
-          _.fold(javaSetOf(b.b.header.id)) { existingBlockIds =>
-            existingBlockIds.add(b.b.header.id)
-            existingBlockIds
+  def removeInputBoxesByErgoTree(inputRecords: InputRecords): Try[_] = Try {
+    inputRecords.byErgoTree.iterator
+      .map { case (ergoTreeHex, inputIds) =>
+        val inputBoxes =
+          inputIds.filter { case (boxId, _) =>
+            boxId != Emission.inputBox && boxId != Foundation.inputBox
           }
-        )
-        List(
-          outErgoTreeFailureOpt,
-          inErgoTreeFailureOpt,
-          outErgoTreeT8FailureOpt,
-          inErgoTreeT8FailureOpt
-        ).flatten.headOption.getOrElse(Success(()))
-      }
-      .map { _ =>
-        store.commit()
-        b
+        ergoTreeHexByUtxo
+          .removeAllOrFail(inputBoxes.keys)
+          .flatMap { _ =>
+            utxosByErgoTreeHex.removeAllOrFail(ergoTreeHex, inputBoxes.iterator.map(_._1), inputBoxes.size) {
+              existingBoxIds =>
+                inputBoxes.iterator.map(_._1).foreach(existingBoxIds.remove)
+                Option(existingBoxIds).collect { case m if !m.isEmpty => m }
+            }
+          }
+          .get
       }
   }
 
+  def removeInputBoxesByErgoTreeT8(inputRecords: InputRecords): Try[_] = Try {
+    inputRecords.byErgoTreeT8.iterator
+      .map { case (ergoTreeT8, inputIds) =>
+        val inputBoxes = inputIds.filter(boxId => boxId != Emission.inputBox && boxId != Foundation.inputBox)
+        utxosByErgoTreeT8Hex
+          .removeAllOrFail(ergoTreeT8, inputBoxes, inputBoxes.size) { existingBoxIds =>
+            inputBoxes.foreach(existingBoxIds.remove)
+            Option(existingBoxIds).collect { case m if !m.isEmpty => m }
+          }
+          .get
+      }
+  }
+
+  def persistErgoTreeTemplateUtxos(outputRecords: ArraySeq[OutputRecord]): Try[_] = Try {
+    outputRecords
+      .filter(_.ergoTreeT8Hex.isDefined)
+      .groupBy(_.ergoTreeT8Hex)
+      .collect { case (Some(ergoTreeT8Hex), boxes) =>
+        utxosByErgoTreeT8Hex
+          .adjustAndForget(
+            ergoTreeT8Hex,
+            boxes.iterator.map(b => b.boxId -> b.creationHeight),
+            boxes.size
+          )
+          .get
+      }
+  }
+
+  def persistErgoTreeUtxos(outputRecords: ArraySeq[OutputRecord]): Try[_] = Try {
+    outputRecords
+      .groupBy(_.ergoTreeHex)
+      .map { case (ergoTreeHex, boxes) =>
+        ergoTreeHexByUtxo
+          .putAllNewOrFail(boxes.iterator.map(b => b.boxId -> b.ergoTreeHex))
+          .flatMap { _ =>
+            utxosByErgoTreeHex.adjustAndForget(ergoTreeHex, boxes.iterator.map(b => b.boxId -> b.value), boxes.size)
+          }
+          .get
+      }
+  }
+
+  def commitNewBlock(
+    blockId: BlockId,
+    blockInfo: BlockInfo,
+    mvStoreConf: MvStoreConf,
+    currentVersion: Revision
+  ): Try[Set[BlockId]] =
+    blockById
+      .putIfAbsentOrFail(blockId, blockInfo.persistable(currentVersion))
+      .map { _ =>
+        blockIdsByHeight
+          .adjust(blockInfo.height)(
+            _.fold(javaSetOf(blockId)) { existingBlockIds =>
+              existingBlockIds.add(blockId)
+              existingBlockIds
+            }
+          )
+      }
+      .map { blockIds =>
+        store.commit()
+        val r = blockIds.asScala.toSet
+        if (blockIds.size > 1) logger.info(s"Fork at height ${blockInfo.height} with ${r.mkString(", ")}")
+        if (blockInfo.height % mvStoreConf.heightCompactRate == 0)
+          compact(true, mvStoreConf.maxIndexingCompactTime, mvStoreConf.maxIdleCompactTime)
+        else Success(())
+        r
+      }
+
   def writeReport: Try[_] = utxosByErgoTreeHex.writeReport
+
+  def compact(
+    indexing: Boolean,
+    maxIndexingCompactTime: MaxCompactTime,
+    maxIdleCompactTime: MaxCompactTime
+  ): Try[Unit] = Try {
+    logger.info(s"Compacting file at $getCompactReport")
+    val compactTime = if (indexing) maxIndexingCompactTime else maxIdleCompactTime
+    val result      = if (!indexing) clear() else Success(())
+    result.map(_ => store.compactFile(compactTime.toMillis.toInt))
+  }
 
   def getCompactReport: String = {
     val height                                                      = getLastHeight.getOrElse(0)
@@ -230,7 +239,6 @@ object MvStorage extends LazyLogging {
   type CacheSize         = Int
   type HeightCompactRate = Int
   type MaxCompactTime    = FiniteDuration
-  type Index             = Long
 
   private val userHomeDir                = System.getProperty("user.home")
   private val tempDir                    = System.getProperty("java.io.tmpdir")

--- a/modules/storage/src/main/scala/org/ergoplatform/uexplorer/storage/MvStoreConf.scala
+++ b/modules/storage/src/main/scala/org/ergoplatform/uexplorer/storage/MvStoreConf.scala
@@ -1,0 +1,10 @@
+package org.ergoplatform.uexplorer.storage
+
+import org.ergoplatform.uexplorer.storage.MvStorage.{CacheSize, HeightCompactRate, MaxCompactTime}
+
+case class MvStoreConf(
+  cacheSize: CacheSize,
+  maxIndexingCompactTime: MaxCompactTime,
+  maxIdleCompactTime: MaxCompactTime,
+  heightCompactRate: HeightCompactRate
+)


### PR DESCRIPTION
Each `MvMap` can be written to concurrently without thread synchronization, let's leverage that as we will soon need to write to 14 `MvMaps` ... otherwise we would increase indexing speed by order of magnitude