### PR TITLE
allow for indexing chain from filesystem instead of Node via http

### DIFF
--- a/modules/chain-indexer/src/main/scala/org/ergoplatform/uexplorer/indexer/ChainIndexer.scala
+++ b/modules/chain-indexer/src/main/scala/org/ergoplatform/uexplorer/indexer/ChainIndexer.scala
@@ -38,7 +38,10 @@ import org.ergoplatform.uexplorer.indexer.config.ChainIndexerConf
 import org.ergoplatform.uexplorer.parser.ErgoTreeParser
 import org.ergoplatform.uexplorer.storage.MvStorage
 
-object Application extends App with AkkaStreamSupport with LazyLogging {
+object ChainIndexer extends App with AkkaStreamSupport with LazyLogging {
+
+  Try(args.headOption).foreach(println)
+
   ChainIndexerConf.loadWithFallback match {
     case Left(failures) =>
       failures.toList.foreach(f => println(s"Config error ${f.description} at ${f.origin}"))
@@ -78,7 +81,7 @@ object Application extends App with AkkaStreamSupport with LazyLogging {
               storage         <- Future.fromTry(MvStorage.withDefaultDir(conf.mvStore.cacheSize))
               utxoTracker   = new UtxoTracker(storage, graphBackendOpt.isDefined)
               blockIndexer  = BlockIndexer(storage, utxoTracker, conf.mvStore)
-              chainIndexer  = new ChainIndexer(backendOpt, graphBackendOpt, blockHttpClient, blockIndexer)
+              chainIndexer  = new ChainIndexer(true, backendOpt, graphBackendOpt, blockHttpClient, blockIndexer)
               mempoolSyncer = new MempoolSyncer(blockHttpClient)
               initializer   = new Initializer(storage, backendOpt, graphBackendOpt)
               scheduler     = new Scheduler(pluginManager, blockIndexer, chainIndexer, mempoolSyncer, initializer)

--- a/modules/chain-indexer/src/main/scala/org/ergoplatform/uexplorer/indexer/tool/DownloadBlocksAsLinesFromNodeToFile.scala
+++ b/modules/chain-indexer/src/main/scala/org/ergoplatform/uexplorer/indexer/tool/DownloadBlocksAsLinesFromNodeToFile.scala
@@ -1,0 +1,64 @@
+package org.ergoplatform.uexplorer.indexer.tool
+
+import akka.actor.CoordinatedShutdown
+import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
+import akka.actor.typed.{ActorSystem, Behavior}
+import akka.stream.scaladsl.{Compression, FileIO, Source}
+import akka.stream.*
+import akka.util.ByteString
+import com.typesafe.scalalogging.LazyLogging
+import org.ergoplatform.uexplorer.http.{BlockHttpClient, LocalNodeUriMagnet, RemoteNodeUriMagnet}
+import org.ergoplatform.uexplorer.indexer.chain.ChainIndexer
+import org.ergoplatform.uexplorer.indexer.config.ChainIndexerConf
+
+import java.io.{PrintWriter, StringWriter}
+import java.nio.file.Paths
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.Duration
+import scala.util.{Failure, Success}
+
+object DownloadBlocksAsLinesFromNodeToFile extends App with LazyLogging {
+
+  private lazy val guardian: Behavior[Nothing] =
+    Behaviors.setup[Nothing] { implicit ctx =>
+      implicit val system: ActorSystem[Nothing] = ctx.system
+
+      val targetFile = Paths.get(System.getProperty("user.home"), ".ergo-uexplorer", "ergo-chain.lines.gz")
+      targetFile.toFile.getParentFile.mkdirs()
+      val chainConf = ChainIndexerConf.loadDefaultOrThrow._1
+
+      implicit val localNodeUriMagnet: LocalNodeUriMagnet   = chainConf.localUriMagnet
+      implicit val remoteNodeUriMagnet: RemoteNodeUriMagnet = chainConf.remoteUriMagnet
+      implicit val killSwitch: SharedKillSwitch             = KillSwitches.shared("uexplorer-kill-switch")
+
+      for
+        blockHttpClient <- BlockHttpClient.withNodePoolBackend
+        bestBlockHeight <- blockHttpClient.getBestBlockHeight
+        _ = println(s"Initiating download from 1 to $bestBlockHeight")
+      yield ChainIndexer
+        .blockIdSource(blockHttpClient, 1)
+        .buffer(20000, OverflowStrategy.backpressure)
+        .mapAsync(1)(blockHttpClient.getBlockForIdAsString)
+        .buffer(20000, OverflowStrategy.backpressure)
+        .map(line => ByteString(line + "\n"))
+        .withAttributes(Attributes.asyncBoundary and Attributes.inputBuffer(0, 64))
+        .via(Compression.gzip)
+        .withAttributes(Attributes.asyncBoundary and Attributes.inputBuffer(0, 64))
+        .runWith(FileIO.toPath(targetFile))
+        .andThen {
+          case Failure(ex) =>
+            val sw = new StringWriter()
+            ex.printStackTrace(new PrintWriter(sw))
+            println(s"Shutting down due to unexpected error:\n$sw")
+            CoordinatedShutdown.get(system).run(CoordinatedShutdown.ActorSystemTerminateReason)
+          case Success(_) =>
+            CoordinatedShutdown.get(system).run(CoordinatedShutdown.ActorSystemTerminateReason)
+        }
+      Behaviors.same
+    }
+
+  lazy val system: ActorSystem[Nothing] = ActorSystem[Nothing](guardian, "download-blocks-as-lines-from-node-to-file")
+  Await.result(system.whenTerminated, Duration.Inf)
+
+}

--- a/modules/chain-indexer/src/test/scala/org/ergoplatform/uexplorer/indexer/SchedulerSpec.scala
+++ b/modules/chain-indexer/src/test/scala/org/ergoplatform/uexplorer/indexer/SchedulerSpec.scala
@@ -85,7 +85,7 @@ class SchedulerSpec extends AsyncFreeSpec with TestSupport with Matchers with Be
   val pluginManager = new PluginManager(List.empty)
   val utxoTracker   = new UtxoTracker(storage, graphBackend.isDefined)
   val blockIndexer  = BlockIndexer(storage, utxoTracker, mvStoreConf)
-  val chainIndexer  = new ChainIndexer(backend, graphBackend, blockClient, blockIndexer)
+  val chainIndexer  = new ChainIndexer(false, backend, graphBackend, blockClient, blockIndexer)
   val mempoolSyncer = new MempoolSyncer(blockClient)
   val initializer   = new Initializer(storage, backend, graphBackend)
   val scheduler     = new Scheduler(pluginManager, blockIndexer, chainIndexer, mempoolSyncer, initializer)

--- a/modules/node-pool/src/main/scala/org/ergoplatform/uexplorer/Resiliency.scala
+++ b/modules/node-pool/src/main/scala/org/ergoplatform/uexplorer/Resiliency.scala
@@ -25,7 +25,7 @@ trait Resiliency {
     interval: FiniteDuration
   )(run: => Future[T]): Source[T, NotUsed] =
     RestartSource
-      .withBackoff(Resiliency.restartSettings) { () =>
+      .withBackoff(Resiliency.restartSettings(interval)) { () =>
         Source
           .tick(initialDelay, interval, ())
           .mapAsync(1)(_ => run)
@@ -41,8 +41,8 @@ trait Resiliency {
 
 object Resiliency extends LazyLogging {
 
-  val restartSettings: RestartSettings = RestartSettings(
-    minBackoff   = 3.seconds,
+  def restartSettings(minBackoff: FiniteDuration): RestartSettings = RestartSettings(
+    minBackoff   = minBackoff,
     maxBackoff   = 30.seconds,
     randomFactor = 0.2 // adds 20% "noise" to vary the intervals slightly
   ).withMaxRestarts(20, 60.minutes) // limits the amount of restarts to 20 within 5 minutes

--- a/modules/storage/src/main/scala/org/ergoplatform/uexplorer/storage/tool/StorageUtils.scala
+++ b/modules/storage/src/main/scala/org/ergoplatform/uexplorer/storage/tool/StorageUtils.scala
@@ -1,8 +1,8 @@
-package org.ergoplatform.uexplorer.storage
+package org.ergoplatform.uexplorer.storage.tool
 
 import org.ergoplatform.ErgoAddressEncoder
-import org.ergoplatform.uexplorer.{Address, ErgoTreeHex, ErgoTreeT8Hex}
 import org.ergoplatform.uexplorer.parser.ErgoTreeParser
+import org.ergoplatform.uexplorer.{Address, ErgoTreeHex, ErgoTreeT8Hex}
 
 import java.io.{BufferedInputStream, FileWriter}
 import java.util.zip.GZIPInputStream
@@ -12,13 +12,13 @@ import scala.util.Success
 object StorageUtils {
   implicit val enc: ErgoAddressEncoder = ErgoAddressEncoder(0.toByte)
 
-  private def writeLinesToFile(lines: IterableOnce[String], filePath: String) = {
+  def writeLinesToFile(lines: IterableOnce[String], filePath: String) = {
     val fileWriter = new FileWriter(filePath)
     try fileWriter.write(lines.iterator.mkString("", "\n", "\n"))
     finally fileWriter.close()
 
   }
-  
+
   def ergoTreesFromAddresses: Set[ErgoTreeHex] =
     Source
       .fromInputStream(
@@ -55,6 +55,5 @@ object StorageUtils {
       .map(k => ErgoTreeParser.ergoTreeHex2T8Hex(ErgoTreeHex.fromStringUnsafe(k)))
       .collect { case Success(Some(t8)) => t8 }
       .toSet
-    
 
 }


### PR DESCRIPTION
For benchmarking purposes it is better to have a stable source of chain blocks, Filesystem. 

There can be a perf issue introduced in new version of Node and it would be hard to figure out why Explorer is suddenly 40% slower.