### PR TITLE
multi-set implementation for one2many indexes persistence

### DIFF
--- a/modules/chain-indexer/src/main/scala/org/ergoplatform/uexplorer/indexer/chain/StorageService.scala
+++ b/modules/chain-indexer/src/main/scala/org/ergoplatform/uexplorer/indexer/chain/StorageService.scala
@@ -24,8 +24,7 @@ import org.ergoplatform.uexplorer.*
 import org.ergoplatform.uexplorer.Const.Protocol.{Emission, Foundation}
 import org.ergoplatform.uexplorer.cassandra.api.Backend
 import org.ergoplatform.uexplorer.chain.ChainTip
-import org.ergoplatform.uexplorer.mvstore.MaxCompactTime
-import org.ergoplatform.uexplorer.mvstore.MultiMapLike.MultiMapSize
+import org.ergoplatform.uexplorer.mvstore.{MaxCompactTime, MultiColSize}
 import org.ergoplatform.uexplorer.mvstore.SuperNodeCollector.Counter
 import org.ergoplatform.uexplorer.node.{ApiFullBlock, ApiTransaction}
 import org.ergoplatform.uexplorer.storage.{MvStorage, MvStoreConf}
@@ -70,7 +69,7 @@ class StorageService(
 
   private def getCompactReport: String = {
     val height                                                      = storage.getLastHeight.getOrElse(0)
-    val MultiMapSize(superNodeSize, superNodeTotalSize, commonSize) = storage.utxosByErgoTreeHex.size
+    val MultiColSize(superNodeSize, superNodeTotalSize, commonSize) = storage.utxosByErgoTreeHex.size
     val nonEmptyAddressCount                                        = superNodeSize + commonSize
     val progress =
       s"storage height: $height, " +

--- a/modules/explorer-core/src/main/scala/org/ergoplatform/uexplorer/Storage.scala
+++ b/modules/explorer-core/src/main/scala/org/ergoplatform/uexplorer/Storage.scala
@@ -31,14 +31,4 @@ trait Storage {
 
   def getErgoTreeHexByUtxo(boxId: BoxId): Option[ErgoTreeHex]
 
-  def getUtxosByErgoTreeHex(ergoTreeHex: ErgoTreeHex): Option[java.util.Map[BoxId, Value]]
-
-  def getUtxoValueByErgoTreeHex(ergoTreeHex: ErgoTreeHex, utxo: BoxId): Option[Value]
-
-  def getUtxoValuesByErgoTreeHex(ergoTreeHex: ErgoTreeHex, utxos: IterableOnce[BoxId]): Option[java.util.Map[BoxId, Value]]
-
-  def getUtxoValuesByErgoTreeT8Hex(
-    ergoTreeHex: ErgoTreeT8Hex,
-    utxos: IterableOnce[BoxId]
-  ): Option[java.util.Map[BoxId, CreationHeight]]
 }

--- a/modules/explorer-core/src/main/scala/org/ergoplatform/uexplorer/uexplorer.scala
+++ b/modules/explorer-core/src/main/scala/org/ergoplatform/uexplorer/uexplorer.scala
@@ -19,7 +19,7 @@ package object uexplorer {
   type Value          = Long
   type Amount         = Long
   type Height         = Int
-  type CreationHeight = Long
+  type CreationHeight = Int
   type Timestamp      = Long
 
   type MinerReward = Long
@@ -83,12 +83,14 @@ package object uexplorer {
   object ErgoTreeHex {
     extension (x: ErgoTreeHex) def unwrapped: String = x
     def fromStringUnsafe(s: String): ErgoTreeHex     = unsafeWrap(refineV[HexStringSpec].unsafeFrom(s))
+    def castUnsafe(s: String): ErgoTreeHex           = s.asInstanceOf[ErgoTreeHex]
   }
 
   type ErgoTreeT8Hex = HexString
   object ErgoTreeT8Hex {
     extension (x: ErgoTreeT8Hex) def unwrapped: String = x
     def fromStringUnsafe(s: String): ErgoTreeT8Hex     = unsafeWrap(HexString.fromStringUnsafe(s))
+    def castUnsafe(s: String): ErgoTreeHex             = s.asInstanceOf[ErgoTreeHex]
   }
 
   opaque type TxId = String

--- a/modules/janusgraph/src/main/scala/org/ergoplatform/uexplorer/janusgraph/JanusGraphWriter.scala
+++ b/modules/janusgraph/src/main/scala/org/ergoplatform/uexplorer/janusgraph/JanusGraphWriter.scala
@@ -10,6 +10,7 @@ import org.ergoplatform.uexplorer.db.{BestBlockInserted, BlockWithInputs, FullBl
 import org.janusgraph.core.Multiplicity
 
 import scala.collection.immutable.{ArraySeq, TreeMap}
+import scala.collection.mutable
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
@@ -47,7 +48,8 @@ trait JanusGraphWriter extends LazyLogging {
       .foreach { case BestBlockInserted(b, _) =>
         b.inputRecords.byTxId.foreach { case (txId, inputRecords) =>
           val outputRecords = b.outputRecords.filter(_.txId == txId)
-          TxGraphWriter.writeGraph(txId, b.info.height, b.info.timestamp, inputRecords, outputRecords)(janusGraph)
+          val fixMe         = mutable.Map.empty[ErgoTreeHex, mutable.Map[BoxId, Value]] // TODO
+          TxGraphWriter.writeGraph(txId, b.info.height, b.info.timestamp, fixMe, outputRecords)(janusGraph)
 
         }
       }

--- a/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/MapLike.scala
+++ b/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/MapLike.scala
@@ -20,7 +20,7 @@ trait MapLike[K, V] {
 
   def removeOrFail(key: K): Try[V]
 
-  def removeAllOrFail(keys: Iterable[K]): Try[Unit]
+  def removeAllOrFail(keys: IterableOnce[K]): Try[Unit]
 
   def ceilingKey(key: K): Option[K]
 

--- a/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/MultiColSize.scala
+++ b/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/MultiColSize.scala
@@ -1,0 +1,3 @@
+package org.ergoplatform.uexplorer.mvstore
+
+case class MultiColSize(superNodeSize: Int, superNodeTotalSize: Int, commonSize: Int)

--- a/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/MvMap.scala
+++ b/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/MvMap.scala
@@ -36,8 +36,8 @@ case class MvMap[K, V: ValueCodec](id: String)(implicit store: MVStore) extends 
         Success(codec.readAll(v))
     }
 
-  def removeAllOrFail(keys: Iterable[K]): Try[Unit] =
-    keys.find(key => underlying.remove(key) == null).fold(Success(())) { key =>
+  def removeAllOrFail(keys: IterableOnce[K]): Try[Unit] =
+    keys.iterator.find(key => underlying.remove(key) == null).fold(Success(())) { key =>
       Failure(new AssertionError(s"Removing non-existing key $key"))
     }
 

--- a/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/multimap/MultiMapCodec.scala
+++ b/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/multimap/MultiMapCodec.scala
@@ -1,5 +1,6 @@
-package org.ergoplatform.uexplorer.mvstore
+package org.ergoplatform.uexplorer.mvstore.multimap
 
+import org.ergoplatform.uexplorer.mvstore.{Appended, ValueCodec}
 import org.h2.mvstore.MVMap
 
 import java.util

--- a/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/multimap/MultiMapLike.scala
+++ b/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/multimap/MultiMapLike.scala
@@ -1,6 +1,6 @@
-package org.ergoplatform.uexplorer.mvstore
+package org.ergoplatform.uexplorer.mvstore.multimap
 
-import org.ergoplatform.uexplorer.mvstore.MultiMapLike.MultiMapSize
+import org.ergoplatform.uexplorer.mvstore.MultiColSize
 
 import scala.util.Try
 
@@ -20,11 +20,7 @@ trait MultiMapLike[PK, C[_, _], K, V] {
 
   def isEmpty: Boolean
 
-  def size: MultiMapSize
+  def size: MultiColSize
 
   def adjustAndForget(pk: PK, entries: IterableOnce[(K, V)], size: Int): Try[_]
-}
-
-object MultiMapLike {
-  case class MultiMapSize(superNodeSize: Int, superNodeTotalSize: Int, commonSize: Int)
 }

--- a/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/multimap/SuperNodeMapCodec.scala
+++ b/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/multimap/SuperNodeMapCodec.scala
@@ -1,13 +1,14 @@
-package org.ergoplatform.uexplorer.mvstore
+package org.ergoplatform.uexplorer.mvstore.multimap
 
 import org.ergoplatform.uexplorer.mvstore
+import org.ergoplatform.uexplorer.mvstore.Appended
 import org.h2.mvstore.MVMap
 
 import java.util
 import java.util.Map.Entry
 import java.util.stream.Collectors
 
-trait SuperNodeCodec[C[_, _], K, V] {
+trait SuperNodeMapCodec[C[_, _], K, V] {
 
   def read(sk: K, m: MVMap[K, V]): Option[V]
 
@@ -21,9 +22,9 @@ trait SuperNodeCodec[C[_, _], K, V] {
 
 }
 
-object SuperNodeCodec {
-  implicit def javaHashMapSuperNodeCodec[K, V]: SuperNodeCodec[java.util.Map, K, V] =
-    new SuperNodeCodec[java.util.Map, K, V] {
+object SuperNodeMapCodec {
+  implicit def javaHashMapSuperNodeCodec[K, V]: SuperNodeMapCodec[java.util.Map, K, V] =
+    new SuperNodeMapCodec[java.util.Map, K, V] {
       override def readAll(from: MVMap[K, V]): util.Map[K, V] =
         from
           .entrySet()

--- a/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/multimap/SuperNodeMapLike.scala
+++ b/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/multimap/SuperNodeMapLike.scala
@@ -1,4 +1,4 @@
-package org.ergoplatform.uexplorer.mvstore
+package org.ergoplatform.uexplorer.mvstore.multimap
 
 import scala.util.Try
 

--- a/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/multimap/SuperNodeMvMap.scala
+++ b/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/multimap/SuperNodeMvMap.scala
@@ -1,22 +1,23 @@
-package org.ergoplatform.uexplorer.mvstore
+package org.ergoplatform.uexplorer.mvstore.multimap
 
 import com.typesafe.scalalogging.LazyLogging
+import org.ergoplatform.uexplorer.mvstore.*
 import org.ergoplatform.uexplorer.mvstore.SuperNodeCollector.Counter
 import org.h2.mvstore.{MVMap, MVStore}
 
 import java.io.File
 import java.nio.file.Path
 import java.util.Map.Entry
-import scala.jdk.CollectionConverters.*
 import java.util.concurrent.ConcurrentHashMap
 import java.util.stream.Collectors
 import scala.collection.concurrent
+import scala.jdk.CollectionConverters.*
 import scala.util.{Failure, Success, Try}
 
 class SuperNodeMvMap[HK, C[_, _], K, V](
   id: String,
   superNodeCollector: SuperNodeCollector[HK]
-)(implicit store: MVStore, codec: SuperNodeCodec[C, K, V], vc: ValueCodec[Counter])
+)(implicit store: MVStore, codec: SuperNodeMapCodec[C, K, V], vc: ValueCodec[Counter])
   extends SuperNodeMapLike[HK, C, K, V]
   with LazyLogging {
 
@@ -189,7 +190,7 @@ class SuperNodeMvMap[HK, C[_, _], K, V](
 object SuperNodeMvMap {
   def apply[HK: HotKeyCodec, C[_, _], K, V](id: String)(implicit
     store: MVStore,
-    sc: SuperNodeCodec[C, K, V],
+    sc: SuperNodeMapCodec[C, K, V],
     vc: ValueCodec[Counter]
   ): SuperNodeMvMap[HK, C, K, V] =
     new SuperNodeMvMap[HK, C, K, V](id, new SuperNodeCollector[HK](id))

--- a/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/multiset/MultiMvSet.scala
+++ b/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/multiset/MultiMvSet.scala
@@ -1,0 +1,51 @@
+package org.ergoplatform.uexplorer.mvstore.multiset
+
+import org.ergoplatform.uexplorer.mvstore.SuperNodeCollector.Counter
+import org.ergoplatform.uexplorer.mvstore.*
+import org.h2.mvstore.MVMap.DecisionMaker
+import org.h2.mvstore.{MVMap, MVStore}
+
+import java.nio.file.Path
+import java.util.Map.Entry
+import java.util.concurrent.{ConcurrentHashMap, ConcurrentMap}
+import java.util.stream.Collectors
+import scala.collection.concurrent
+import scala.jdk.CollectionConverters.*
+import scala.util.{Failure, Success, Try}
+
+case class MultiMvSet[K, C[_], V](
+  id: MultiColId
+)(implicit
+  store: MVStore,
+  c: MultiSetCodec[C, V],
+  sc: SuperNodeSetCodec[C, V],
+  vc: ValueCodec[Counter],
+  kc: HotKeyCodec[K]
+) extends MultiSetLike[K, C, V] {
+
+  private val commonMap: MapLike[K, C[V]]           = new MvMap[K, C[V]](id)
+  private val superNodeMap: SuperNodeMvSet[K, C, V] = SuperNodeMvSet[K, C, V](id)
+
+  def isEmpty: Boolean = superNodeMap.isEmpty && commonMap.isEmpty
+
+  def size: MultiColSize = MultiColSize(superNodeMap.size, superNodeMap.totalSize, commonMap.size)
+
+  def clearEmptySuperNodes(): Try[Unit] =
+    superNodeMap.clearEmptySuperNodes()
+
+  def getReport: (Path, Vector[(String, Counter)]) =
+    ergoHomeDir.resolve(s"hot-keys-$id-$randomNumberPerRun.csv") -> superNodeMap.getReport
+
+  def removeSubsetOrFail(k: K, values: IterableOnce[V], size: Int)(f: C[V] => Option[C[V]]): Try[Unit] =
+    superNodeMap.removeAllOrFail(k, values, size).fold(commonMap.removeOrUpdateOrFail(k)(f))(identity)
+
+  def adjustAndForget(k: K, values: IterableOnce[V], size: Int): Try[_] =
+    superNodeMap.putAllNewOrFail(k, values, size).getOrElse {
+      val (appended, _) = commonMap.adjustCollection(k)(c.append(values))
+      if (appended)
+        Success(())
+      else
+        Failure(new AssertionError(s"All inserted values under key $k should be appended"))
+    }
+
+}

--- a/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/multiset/MultiSetCodec.scala
+++ b/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/multiset/MultiSetCodec.scala
@@ -1,0 +1,19 @@
+package org.ergoplatform.uexplorer.mvstore.multiset
+
+import org.ergoplatform.uexplorer.mvstore.{Appended, ValueCodec}
+import org.h2.mvstore.MVMap
+
+import java.util
+import java.util.Map.Entry
+import java.util.stream.Collectors
+
+trait MultiSetCodec[C[_], V] extends ValueCodec[C[V]] {
+
+  def readAll(bytes: Array[Byte]): C[V]
+
+  def writeAll(map: C[V]): Array[Byte]
+
+  def append(xs: IterableOnce[V])(
+    existingOpt: Option[C[V]]
+  ): (Appended, C[V])
+}

--- a/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/multiset/MultiSetLike.scala
+++ b/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/multiset/MultiSetLike.scala
@@ -1,0 +1,16 @@
+package org.ergoplatform.uexplorer.mvstore.multiset
+
+
+import org.ergoplatform.uexplorer.mvstore.MultiColSize
+
+import scala.util.Try
+
+trait MultiSetLike[K, C[_], V] {
+
+  def isEmpty: Boolean
+
+  def size: MultiColSize
+
+  def removeSubsetOrFail(k: K, values: IterableOnce[V], size: Int)(f: C[V] => Option[C[V]]): Try[Unit]
+  def adjustAndForget(k: K, values: IterableOnce[V], size: Int): Try[_]
+}

--- a/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/multiset/SuperNodeMvSet.scala
+++ b/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/multiset/SuperNodeMvSet.scala
@@ -1,0 +1,149 @@
+package org.ergoplatform.uexplorer.mvstore.multiset
+
+import com.typesafe.scalalogging.LazyLogging
+import org.ergoplatform.uexplorer.mvstore.*
+import org.ergoplatform.uexplorer.mvstore.SuperNodeCollector.Counter
+import org.h2.mvstore.db.NullValueDataType
+import org.h2.mvstore.{MVMap, MVStore}
+import org.h2.value.Value
+
+import java.io.File
+import java.nio.file.Path
+import java.util.Map.Entry
+import java.util.concurrent.ConcurrentHashMap
+import java.util.stream.Collectors
+import scala.collection.concurrent
+import scala.jdk.CollectionConverters.*
+import scala.util.{Failure, Success, Try}
+
+class SuperNodeMvSet[HK, C[_], V](
+  id: String,
+  superNodeCollector: SuperNodeCollector[HK]
+)(implicit store: MVStore, codec: SuperNodeSetCodec[C, V], vc: ValueCodec[Counter])
+  extends SuperNodeSetLike[HK, C, V]
+  with LazyLogging {
+
+  private lazy val existingMapsByHotKey: concurrent.Map[HK, MVMap[V, Value]] =
+    new ConcurrentHashMap[HK, MVMap[V, Value]]().asScala.addAll(
+      superNodeCollector
+        .getExistingStringifiedHotKeys(store.getMapNames.asScala.toSet)
+        .view
+        .mapValues { name =>
+          store.openMap(
+            name,
+            MVMap.Builder[V, Value].valueType(NullValueDataType.INSTANCE)
+          )
+        }
+        .toMap
+    )
+
+  private lazy val counterByHotKey = new MvMap[HK, Counter](s"$id-counter")
+
+  private def collectReadHotKey(k: HK): Counter =
+    counterByHotKey.adjust(k)(_.fold(Counter(1, 1, 0, 0)) { case Counter(writeOps, readOps, added, removed) =>
+      Counter(writeOps + 1, readOps + 1, added, removed)
+    })
+
+  private def collectInsertedHotKey(k: HK, size: Int): Counter =
+    counterByHotKey.adjust(k)(_.fold(Counter(1, 0, size, 0)) { case Counter(writeOps, readOps, added, removed) =>
+      Counter(writeOps + 1, readOps, added + size, removed)
+    })
+
+  private def collectRemovedHotKey(k: HK, size: Int): Option[Counter] =
+    counterByHotKey.removeOrUpdate(k) { case Counter(writeOps, readOps, added, removed) =>
+      Some(Counter(writeOps + 1, readOps, added, removed + size))
+    }
+
+  def clearEmptySuperNodes(): Try[Unit] = Try {
+    val emptyMaps =
+      existingMapsByHotKey
+        .foldLeft(Set.newBuilder[HK]) {
+          case (acc, (hotKey, map)) if map.isEmpty =>
+            acc.addOne(hotKey)
+          case (acc, _) =>
+            acc
+        }
+        .result()
+    logger.info(s"Going to remove ${emptyMaps.size} empty $id supernode maps")
+    emptyMaps
+      .foreach { hk =>
+        existingMapsByHotKey
+          .remove(hk)
+          .foreach(store.removeMap)
+      }
+  }
+
+  def getReport: Vector[(String, Counter)] =
+    superNodeCollector
+      .filterAndSortHotKeys(counterByHotKey.iterator(None, None, false))
+
+  def putAllNewOrFail(hotKey: HK, values: IterableOnce[V], size: Int): Option[Try[Unit]] =
+    superNodeCollector
+      .getHotKeyString(hotKey)
+      .map { superNodeName =>
+        val replacedValueOpt =
+          existingMapsByHotKey.get(hotKey) match {
+            case None =>
+              val newSuperNodeMap: MVMap[V, Value] =
+                store.openMap(
+                  superNodeName,
+                  MVMap.Builder[V, Value].valueType(NullValueDataType.INSTANCE)
+                )
+              existingMapsByHotKey.putIfAbsent(hotKey, newSuperNodeMap)
+              codec.writeAll(newSuperNodeMap, values)
+            case Some(m) =>
+              codec.writeAll(m, values)
+          }
+        replacedValueOpt
+          .map(v => Failure(new AssertionError(s"In $id, secondary-key $v was already present under hotkey $hotKey!")))
+          .getOrElse(Success(()))
+      }
+      .orElse {
+        collectInsertedHotKey(hotKey, size)
+        None
+      }
+
+  def removeAllOrFail(hotKey: HK, values: IterableOnce[V], size: Int): Option[Try[Unit]] =
+    superNodeCollector
+      .getHotKeyString(hotKey)
+      .flatMap { superNodeName =>
+        existingMapsByHotKey.get(hotKey).map { mvMap =>
+          values.iterator
+            .find(k => mvMap.remove(k) == null)
+            .fold(Success(())) { sk =>
+              Failure(new AssertionError(s"In $id, removing non-existing secondary key $sk from superNode $superNodeName"))
+            } // we don't remove supernode map when it gets empty as common map as  on/off/on/off is expensive
+        /*
+            .flatMap { _ =>
+              if (mvMap.isEmpty) {
+                logger.info(s"Removing supernode map for $superNodeName as it was emptied")
+                existingSupernodeMapsByKey.remove(sk).fold(Try(store.removeMap(superNodeName))) { m =>
+                  Try(store.removeMap(m))
+                }
+              } else
+                Success(())
+            }
+         */
+        }
+      }
+      .orElse {
+        collectRemovedHotKey(hotKey, size)
+        None
+      }
+
+  def isEmpty: Boolean = existingMapsByHotKey.forall(_._2.isEmpty)
+
+  def size: Int = existingMapsByHotKey.size
+
+  def totalSize: Int = existingMapsByHotKey.iterator.map(_._2.size()).sum
+
+}
+
+object SuperNodeMvSet {
+  def apply[HK: HotKeyCodec, C[_], V](id: String)(implicit
+    store: MVStore,
+    sc: SuperNodeSetCodec[C, V],
+    vc: ValueCodec[Counter]
+  ): SuperNodeMvSet[HK, C, V] =
+    new SuperNodeMvSet[HK, C, V](id, new SuperNodeCollector[HK](id))
+}

--- a/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/multiset/SuperNodeSetCodec.scala
+++ b/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/multiset/SuperNodeSetCodec.scala
@@ -1,0 +1,39 @@
+package org.ergoplatform.uexplorer.mvstore.multiset
+
+import org.ergoplatform.uexplorer.mvstore
+import org.ergoplatform.uexplorer.mvstore.Appended
+import org.h2.mvstore.MVMap
+import org.h2.mvstore.db.NullValueDataType
+import org.h2.value.{Value, ValueNull}
+
+import java.util
+import java.util.Map.Entry
+import java.util.stream.Collectors
+
+trait SuperNodeSetCodec[C[_], V] {
+
+  def contains(value: V, m: MVMap[V, Value]): Boolean
+
+  def write(to: MVMap[V, Value], value: V): Appended
+
+  def readAll(m: MVMap[V, Value]): C[V]
+
+  def writeAll(to: MVMap[V, Value], from: IterableOnce[V]): Option[V]
+
+}
+
+object SuperNodeSetCodec {
+  implicit def javaHashSetSuperNodeCodec[V]: SuperNodeSetCodec[java.util.Set, V] =
+    new SuperNodeSetCodec[java.util.Set, V] {
+      override def readAll(from: MVMap[V, Value]): util.Set[V] =
+        new java.util.HashSet[V](from.keySet())
+
+      override def writeAll(to: MVMap[V, Value], from: IterableOnce[V]): Option[V] =
+        from.iterator.find(v => !write(to, v))
+
+      override def contains(value: V, m: MVMap[V, Value]): Boolean = m.containsKey(value)
+
+      override def write(to: MVMap[V, Value], value: V): Appended =
+        to.put(value, ValueNull.INSTANCE) == null
+    }
+}

--- a/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/multiset/SuperNodeSetLike.scala
+++ b/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/multiset/SuperNodeSetLike.scala
@@ -1,0 +1,17 @@
+package org.ergoplatform.uexplorer.mvstore.multiset
+
+import scala.util.Try
+
+trait SuperNodeSetLike[K, C[_], V] {
+
+  def putAllNewOrFail(hotKey: K, values: IterableOnce[V], size: Int): Option[Try[Unit]]
+
+  def removeAllOrFail(hotKey: K, values: IterableOnce[V], size: Int): Option[Try[Unit]]
+
+  def isEmpty: Boolean
+
+  def size: Int
+
+  def totalSize: Int
+
+}

--- a/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/package.scala
+++ b/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/package.scala
@@ -15,16 +15,24 @@ package object mvstore {
   type CacheSize         = Int
   type HeightCompactRate = Int
   type MaxCompactTime    = FiniteDuration
-  type MultiMapId        = String
+  type MultiColId        = String
 
   type Appended = Boolean // put & not replaced
   type Updated  = Boolean // put & replaced
   type Removed  = Boolean // removed existing
   type Replaced = Boolean // replaced given value
 
-  def javaSetOf[T](e: T): java.util.Set[T] = {
-    val set = new java.util.HashSet[T]()
+  def javaSetOf[V](e: V): java.util.Set[V] = {
+    val set = new java.util.HashSet[V]()
     set.add(e)
+    set
+  }
+
+  def javaSetOf[V](values: IterableOnce[V]): java.util.Set[V] = {
+    val set = new java.util.HashSet[V]()
+    values.iterator.foreach { value =>
+      set.add(value)
+    }
     set
   }
 

--- a/modules/storage/src/main/scala/org/ergoplatform/uexplorer/storage/Implicits.scala
+++ b/modules/storage/src/main/scala/org/ergoplatform/uexplorer/storage/Implicits.scala
@@ -4,14 +4,18 @@ import org.ergoplatform.uexplorer.{ErgoTreeHex, *}
 import org.ergoplatform.uexplorer.db.BlockInfo
 import org.ergoplatform.uexplorer.mvstore.*
 import org.ergoplatform.uexplorer.mvstore.SuperNodeCollector.Counter
+import org.ergoplatform.uexplorer.mvstore.multimap.MultiMapCodec
+import org.ergoplatform.uexplorer.mvstore.multiset.MultiSetCodec
 import org.ergoplatform.uexplorer.storage.kryo.*
 
 object Implicits {
-  implicit val blockIdsCodec: ValueCodec[java.util.Set[BlockId]]           = BlockIdsCodec
-  implicit val valueByBoxCodec: MultiMapCodec[java.util.Map, BoxId, Value] = ValueByBoxCodec
-  implicit val blockInfoCodec: ValueCodec[BlockInfo]                       = BlockInfoCodec
-  implicit val counterCodec: ValueCodec[Counter]                           = CounterCodec
-  implicit val addressCodec: ValueCodec[ErgoTreeHex]                       = ErgoTreeHexCodec
+  implicit def valueByBoxCodec[V]: MultiMapCodec[java.util.Map, BoxId, V] = new ValueByBoxCodec[V]
+
+  implicit val blockIdsCodec: ValueCodec[java.util.Set[BlockId]] = BlockIdsCodec
+  implicit val boxCodec: MultiSetCodec[java.util.Set, BoxId]     = BoxCodec
+  implicit val blockInfoCodec: ValueCodec[BlockInfo]             = BlockInfoCodec
+  implicit val counterCodec: ValueCodec[Counter]                 = CounterCodec
+  implicit val addressCodec: ValueCodec[ErgoTreeHex]             = ErgoTreeHexCodec
 
   implicit val hexCodec: HotKeyCodec[HexString] = new HotKeyCodec[HexString] {
     import org.ergoplatform.uexplorer.HexString.unwrapped

--- a/modules/storage/src/main/scala/org/ergoplatform/uexplorer/storage/kryo/BoxCodec.scala
+++ b/modules/storage/src/main/scala/org/ergoplatform/uexplorer/storage/kryo/BoxCodec.scala
@@ -1,0 +1,53 @@
+package org.ergoplatform.uexplorer.storage.kryo
+
+import com.esotericsoftware.kryo.Kryo
+import com.esotericsoftware.kryo.io.{ByteBufferOutput, Input}
+import com.esotericsoftware.kryo.serializers.DefaultSerializers.CollectionsSingletonSetSerializer
+import com.esotericsoftware.kryo.serializers.ImmutableCollectionsSerializers.JdkImmutableSetSerializer
+import com.esotericsoftware.kryo.serializers.{ImmutableCollectionsSerializers, MapSerializer}
+import com.esotericsoftware.kryo.util.Pool
+import org.ergoplatform.uexplorer.db.BlockInfo
+import org.ergoplatform.uexplorer.mvstore.*
+import org.ergoplatform.uexplorer.mvstore.multiset.MultiSetCodec
+import org.ergoplatform.uexplorer.{BoxId, ErgoTreeHex, Height}
+
+import java.nio.ByteBuffer
+import java.util
+import scala.jdk.CollectionConverters.*
+import scala.language.unsafeNulls
+import scala.util.Try
+
+object BoxCodec extends MultiSetCodec[java.util.Set, BoxId] {
+
+  override def readAll(bytes: Array[Byte]): java.util.Set[BoxId] = {
+    val input = new Input(bytes)
+    val kryo  = KryoSerialization.pool.obtain()
+    try kryo.readObject(input, classOf[util.HashSet[BoxId]])
+    finally {
+      KryoSerialization.pool.free(kryo)
+      input.close()
+    }
+  }
+
+  override def writeAll(values: java.util.Set[BoxId]): Array[Byte] = {
+    val buffer = ByteBuffer.allocate((values.size() * 70) + 512)
+    val output = new ByteBufferOutput(buffer)
+    val kryo   = KryoSerialization.pool.obtain()
+    try kryo.writeObject(output, values)
+    finally {
+      KryoSerialization.pool.free(kryo)
+      output.close()
+    }
+    buffer.array()
+  }
+
+  override def append(values: IterableOnce[BoxId])(
+    existingOpt: Option[java.util.Set[BoxId]]
+  ): (Appended, java.util.Set[BoxId]) =
+    existingOpt.fold(true -> javaSetOf(values)) { existingSet =>
+      values.iterator.forall { v =>
+        existingSet.add(v)
+      } -> existingSet
+    }
+
+}

--- a/modules/storage/src/main/scala/org/ergoplatform/uexplorer/storage/kryo/KryoSerialization.scala
+++ b/modules/storage/src/main/scala/org/ergoplatform/uexplorer/storage/kryo/KryoSerialization.scala
@@ -4,15 +4,17 @@ import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.io.{ByteBufferOutput, Input}
 import com.esotericsoftware.kryo.serializers.DefaultSerializers.CollectionsSingletonSetSerializer
 import com.esotericsoftware.kryo.serializers.ImmutableCollectionsSerializers.JdkImmutableSetSerializer
-import com.esotericsoftware.kryo.serializers.{ImmutableCollectionsSerializers, MapSerializer}
+import com.esotericsoftware.kryo.serializers.{CollectionSerializer, ImmutableCollectionsSerializers, MapSerializer}
 import com.esotericsoftware.kryo.util.Pool
 import org.ergoplatform.uexplorer.db.BlockInfo
 import org.ergoplatform.uexplorer.mvstore.SuperNodeCollector.Counter
-import org.ergoplatform.uexplorer.mvstore.{MultiMapCodec, ValueCodec}
+import org.ergoplatform.uexplorer.mvstore.ValueCodec
+import org.ergoplatform.uexplorer.mvstore.multimap.MultiMapCodec
 import org.ergoplatform.uexplorer.storage.kryo.*
 
 import java.nio.ByteBuffer
 import java.util
+import java.util.{Collections, HashSet, Set}
 import scala.util.Try
 
 object KryoSerialization {
@@ -21,14 +23,16 @@ object KryoSerialization {
     protected def create: Kryo = {
       val kryo          = new Kryo()
       val mapSerializer = new MapSerializer()
-      val setSerializer = new CollectionsSingletonSetSerializer()
+      val setSerializer = new CollectionSerializer[util.Set[AnyRef]]()
 
       kryo.setRegistrationRequired(true)
+      kryo.register(Collections.singleton(null).getClass)
       kryo.register(classOf[util.HashMap[_, _]], mapSerializer)
       kryo.register(classOf[util.HashSet[_]], setSerializer)
       kryo.register(classOf[Counter])
       kryo.register(classOf[BlockInfo])
       setSerializer.setAcceptsNull(false)
+      setSerializer.setElementsCanBeNull(false)
       mapSerializer.setKeyClass(classOf[String], kryo.getSerializer(classOf[String]))
       mapSerializer.setKeysCanBeNull(false)
       mapSerializer.setValueClass(classOf[java.lang.Long], kryo.getSerializer(classOf[java.lang.Long]))


### PR DESCRIPTION
Existing multiMap `Map[PK, Map[SK, ?]]` is not really that useful as we need many `OneToMany` persistent indexes `Map[PK, Set[SK, ?]]` ...

Whole uexplorer's datamodel will be composed of
- bunch of persistent supernode-resistant Indexes of unspent boxes. Persistent indexes are the "source of truth" reflecting utxo state of Node, all transactional changes can be rolled back in case of a fork. 
- eventually two h2 tables with all data, one for spent boxes (with in-memory indexes) and one for unspent boxes

This will have predictable both indexing and querying performance as unspent boxes h2 table should be accessed not so  often with limited queries.