### PR TITLE
chain fix after out of memory error

### DIFF
--- a/modules/backend/src/main/scala/org/ergoplatform/uexplorer/backend/H2Backend.scala
+++ b/modules/backend/src/main/scala/org/ergoplatform/uexplorer/backend/H2Backend.scala
@@ -17,7 +17,7 @@ object H2Backend extends Backend {
   def layer: ZLayer[Any, Throwable, HikariDataSource] = ZLayer.scoped(
     ZIO.acquireRelease(
       ZIO.attempt(JdbcContextConfig(LoadConfig("h2")).dataSource)
-    )(ds => ZIO.succeed(ds.close()))
+    )(ds => ZIO.log(s"Closing h2 backend") *> ZIO.succeed(ds.close()))
   )
 
   def server(): ZIO[DataSource with BoxService with BlockRepo, Throwable, Fiber.Runtime[Nothing, Nothing]] =

--- a/modules/backend/src/main/scala/org/ergoplatform/uexplorer/backend/PersistentRepo.scala
+++ b/modules/backend/src/main/scala/org/ergoplatform/uexplorer/backend/PersistentRepo.scala
@@ -29,6 +29,9 @@ case class PersistentRepo(ds: DataSource, blockRepo: BlockRepo, boxRepo: BoxRepo
     persistBlockInTx(b.block, outputs, inputs, preTx, postTx)
   }
 
+  override def getLastBlock: Task[Option[Block]] =
+    blockRepo.getLastBlocks(1).map(_.lastOption)
+
   private def persistBlockInTx(
     block: Block,
     outputs: OutputRecords,

--- a/modules/backend/src/main/scala/org/ergoplatform/uexplorer/backend/Repo.scala
+++ b/modules/backend/src/main/scala/org/ergoplatform/uexplorer/backend/Repo.scala
@@ -11,6 +11,8 @@ trait Repo:
   def removeBlocks(blockIds: Set[BlockId]): Task[Unit]
 
   def writeBlock(b: LinkedBlock)(preTx: Task[Any], postTx: Task[Any]): Task[BlockId]
+  
+  def getLastBlock: Task[Option[Block]]
 
 object Repo:
   def writeBlock(b: LinkedBlock)(preTx: Task[Any], postTx: Task[Any]): ZIO[Repo, Throwable, BlockId] =

--- a/modules/backend/src/main/scala/org/ergoplatform/uexplorer/backend/blocks/BlockRepo.scala
+++ b/modules/backend/src/main/scala/org/ergoplatform/uexplorer/backend/blocks/BlockRepo.scala
@@ -7,6 +7,8 @@ import zio.*
 trait BlockRepo:
   def insert(block: Block): Task[BlockId]
 
+  def getLastBlocks(n: Int): Task[List[Block]]
+
   def lookup(headerId: BlockId): Task[Option[Block]]
 
   def lookupBlocks(ids: Set[BlockId]): Task[List[Block]]
@@ -20,6 +22,9 @@ trait BlockRepo:
 object BlockRepo:
   def insert(block: Block): ZIO[BlockRepo, Throwable, BlockId] =
     ZIO.serviceWithZIO[BlockRepo](_.insert(block))
+
+  def getLastBlocks(n: Int): ZIO[BlockRepo, Throwable, List[Block]] =
+    ZIO.serviceWithZIO[BlockRepo](_.getLastBlocks(n))
 
   def lookup(headerId: BlockId): ZIO[BlockRepo, Throwable, Option[Block]] =
     ZIO.serviceWithZIO[BlockRepo](_.lookup(headerId))

--- a/modules/backend/src/main/scala/org/ergoplatform/uexplorer/backend/blocks/PersistentBlockRepo.scala
+++ b/modules/backend/src/main/scala/org/ergoplatform/uexplorer/backend/blocks/PersistentBlockRepo.scala
@@ -29,6 +29,17 @@ case class PersistentBlockRepo(ds: DataSource) extends BlockRepo with Codecs:
       .as(block.blockId)
       .provide(dsLayer)
 
+  override def getLastBlocks(n: Int): Task[List[Block]] =
+    ctx
+      .run {
+        quote {
+          query[Block]
+            .sortBy(_.height)(Ord.desc[Int])
+            .take(lift(n))
+        }
+      }
+      .provide(dsLayer)
+
   override def lookup(headerId: BlockId): Task[Option[Block]] =
     ctx
       .run {

--- a/modules/backend/src/main/scala/org/ergoplatform/uexplorer/backend/boxes/PersistentBoxRepo.scala
+++ b/modules/backend/src/main/scala/org/ergoplatform/uexplorer/backend/boxes/PersistentBoxRepo.scala
@@ -52,20 +52,12 @@ case class PersistentBoxRepo(ds: DataSource) extends BoxRepo with Codecs:
     utxos: Iterable[Utxo]
   ): Task[Iterable[BoxId]] =
     (for {
-      _ <- ZIO.collectAllParDiscard(
-             List(
-               ctx.run(insertErgoTreesQuery(ergoTrees)),
-               ctx.run(insertErgoTreeT8sQuery(ergoTreeT8s)),
-               ctx.run(insertAssets(assets))
-             )
-           )
+      _ <- ctx.run(insertErgoTreesQuery(ergoTrees))
+      _ <- ctx.run(insertErgoTreeT8sQuery(ergoTreeT8s))
+      _ <- ctx.run(insertAssets(assets))
       _ <- ctx.run(insertBoxesQuery(utxos.map(_.toBox)))
-      _ <- ZIO.collectAllParDiscard(
-             List(
-               ctx.run(insertAssetsToBox(assetsToBox)),
-               ctx.run(insertUtxosQuery(utxos))
-             )
-           )
+      _ <- ctx.run(insertAssetsToBox(assetsToBox))
+      _ <- ctx.run(insertUtxosQuery(utxos))
     } yield utxos.map(_.boxId)).provide(dsLayer)
 
   override def deleteUtxo(boxId: BoxId): Task[Long] =

--- a/modules/chain-indexer/src/main/scala/org/ergoplatform/uexplorer/indexer/ChainIndexer.scala
+++ b/modules/chain-indexer/src/main/scala/org/ergoplatform/uexplorer/indexer/ChainIndexer.scala
@@ -1,36 +1,21 @@
 package org.ergoplatform.uexplorer.indexer
 
-import org.ergoplatform.ErgoAddressEncoder
-import org.ergoplatform.uexplorer.CoreConf
-import org.ergoplatform.uexplorer.backend.{H2Backend, PersistentRepo}
 import org.ergoplatform.uexplorer.backend.blocks.{BlockRepo, PersistentBlockRepo}
 import org.ergoplatform.uexplorer.backend.boxes.PersistentBoxRepo
-import org.ergoplatform.uexplorer.config.ExplorerConfig
-import org.ergoplatform.uexplorer.db.{FullBlock, GraphBackend}
+import org.ergoplatform.uexplorer.backend.{H2Backend, PersistentRepo}
+import org.ergoplatform.uexplorer.db.GraphBackend
 import org.ergoplatform.uexplorer.http.*
 import org.ergoplatform.uexplorer.indexer.chain.*
 import org.ergoplatform.uexplorer.indexer.config.ChainIndexerConf
 import org.ergoplatform.uexplorer.indexer.db.{Backend, GraphBackend}
 import org.ergoplatform.uexplorer.indexer.mempool.{MemPool, MempoolSyncer}
 import org.ergoplatform.uexplorer.indexer.plugin.PluginManager
-import org.ergoplatform.uexplorer.parser.ErgoTreeParser
-import org.ergoplatform.uexplorer.plugin.Plugin
 import org.ergoplatform.uexplorer.storage.{MvStorage, MvStoreConf}
-import org.slf4j.LoggerFactory
-import sttp.client3.httpclient.zio.HttpClientZioBackend
 import zio.*
-import zio.config.typesafe.TypesafeConfigProvider
 import zio.logging.LogFormat
 import zio.logging.backend.SLF4J
 
-import java.io.{PrintWriter, StringWriter}
-import java.util.ServiceLoader
-import scala.collection.immutable.{ArraySeq, ListMap}
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration.*
-import scala.concurrent.{Await, Future}
 import scala.language.postfixOps
-import scala.util.{Failure, Success, Try}
 
 object ChainIndexer extends ZIOAppDefault {
 

--- a/modules/chain-indexer/src/main/scala/org/ergoplatform/uexplorer/indexer/StreamScheduler.scala
+++ b/modules/chain-indexer/src/main/scala/org/ergoplatform/uexplorer/indexer/StreamScheduler.scala
@@ -56,7 +56,6 @@ case class StreamScheduler(
 
       case ChainValid =>
         for {
-          _     <- ZIO.log(s"Chain is valid, continue loading ...")
           fiber <- nodePoolBackend.keepNodePoolUpdated
           _     <- periodicSync.repeat(schedule)
         } yield fiber

--- a/modules/chain-indexer/src/main/scala/org/ergoplatform/uexplorer/indexer/chain/StreamExecutor.scala
+++ b/modules/chain-indexer/src/main/scala/org/ergoplatform/uexplorer/indexer/chain/StreamExecutor.scala
@@ -1,26 +1,16 @@
 package org.ergoplatform.uexplorer.indexer.chain
 
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource
-import org.ergoplatform.ErgoAddressEncoder
-import org.ergoplatform.uexplorer.ExeContext.Implicits
-import org.ergoplatform.uexplorer.chain.{ChainLinker, ChainTip}
+import org.ergoplatform.uexplorer.ReadableStorage
+import org.ergoplatform.uexplorer.chain.ChainLinker
 import org.ergoplatform.uexplorer.db.*
-import org.ergoplatform.uexplorer.http.{BlockHttpClient, Codecs}
+import org.ergoplatform.uexplorer.http.BlockHttpClient
 import org.ergoplatform.uexplorer.indexer.chain.StreamExecutor.*
 import org.ergoplatform.uexplorer.indexer.config.ChainIndexerConf
-import org.ergoplatform.uexplorer.indexer.db.Backend
-import org.ergoplatform.uexplorer.node.ApiFullBlock
-import org.ergoplatform.uexplorer.storage.MvStorage
-import org.ergoplatform.uexplorer.{BlockId, CoreConf, Height, ReadableStorage}
-
-import java.nio.file.{Path, Paths}
-import java.util.concurrent.ConcurrentHashMap
-import scala.collection.concurrent
-import scala.collection.immutable.{ListMap, TreeSet}
-import scala.jdk.CollectionConverters.*
-import scala.util.{Failure, Success, Try}
-import zio.stream.*
 import zio.*
+import zio.stream.*
+
+import scala.jdk.CollectionConverters.*
 
 case class StreamExecutor(
   blockHttpClient: BlockHttpClient,
@@ -32,8 +22,7 @@ case class StreamExecutor(
 
   def indexNewBlocks: Task[ChainSyncResult] =
     for
-      _        <- blockHttpClient.getBestBlockHeight
-      chainTip <- storage.getChainTip
+      chainTip <- blockWriter.getChainTip
       chainLinker = new ChainLinker(blockHttpClient.getBlockForId, chainTip)(conf.core)
       blockSource = blockReader.getBlockSource(storage.getLastHeight.getOrElse(0) + 1, conf.benchmarkMode)
       syncResult <- blockWriter.insertBranchFlow(blockSource, chainLinker)

--- a/modules/chain-indexer/src/main/scala/org/ergoplatform/uexplorer/indexer/db/Backend.scala
+++ b/modules/chain-indexer/src/main/scala/org/ergoplatform/uexplorer/indexer/db/Backend.scala
@@ -19,20 +19,14 @@ import scala.util.Try
 
 object Backend {
 
-  def layerH2: ZLayer[Any, Throwable, HikariDataSource] = ZLayer.scoped(
-    ZIO.acquireRelease(
-      ZIO.attempt(JdbcContextConfig(LoadConfig("h2")).dataSource)
-    )(ds => ZIO.succeed(ds.close()))
-  )
-
   def runServer: ZIO[ChainIndexerConf, Throwable, Fiber.Runtime[Nothing, Nothing]] =
     ZIO.serviceWithZIO[ChainIndexerConf] { conf =>
       conf.backendType match {
         case Cassandra(parallelism) =>
           // CassandraBackend(parallelism) // TODO cassandra must become Repos !
-          H2Backend.server().provide(layerH2, CoreConf.layer, BoxService.layer, PersistentBlockRepo.layer, PersistentBoxRepo.layer)
+          H2Backend.server().provide(H2Backend.layer, CoreConf.layer, BoxService.layer, PersistentBlockRepo.layer, PersistentBoxRepo.layer)
         case H2(parallelism) =>
-          H2Backend.server().provide(layerH2, CoreConf.layer, BoxService.layer, PersistentBlockRepo.layer, PersistentBoxRepo.layer)
+          H2Backend.server().provide(H2Backend.layer, CoreConf.layer, BoxService.layer, PersistentBlockRepo.layer, PersistentBoxRepo.layer)
       }
 
     }

--- a/modules/chain-indexer/src/main/scala/org/ergoplatform/uexplorer/indexer/db/GraphBackend.scala
+++ b/modules/chain-indexer/src/main/scala/org/ergoplatform/uexplorer/indexer/db/GraphBackend.scala
@@ -27,13 +27,13 @@ object GraphBackend {
           ZLayer.scoped(
             ZIO.acquireRelease(
               ZIO.attempt(new InMemoryGraphBackend) // TODO switch to JanusGraph
-            )(gb => ZIO.succeed(gb.close()))
+            )(gb => ZIO.log(s"Closing graph backend") *> ZIO.succeed(gb.close()))
           )
         case InMemoryGraph(parallelism) =>
           ZLayer.scoped(
             ZIO.acquireRelease(
               ZIO.attempt(new InMemoryGraphBackend)
-            )(gb => ZIO.succeed(gb.close()))
+            )(gb => ZIO.log(s"Closing graph backend") *> ZIO.succeed(gb.close()))
           )
       }
     }

--- a/modules/chain-indexer/src/main/scala/org/ergoplatform/uexplorer/indexer/plugin/PluginManager.scala
+++ b/modules/chain-indexer/src/main/scala/org/ergoplatform/uexplorer/indexer/plugin/PluginManager.scala
@@ -60,7 +60,9 @@ object PluginManager {
       ZIO
         .collectAllParDiscard(plugins.map(_.init))
         .flatMap { _ =>
-          ZIO.acquireRelease(ZIO.succeed(PluginManager(plugins)))(p => ZIO.succeed(p.close()))
+          ZIO.acquireRelease(
+            ZIO.succeed(PluginManager(plugins))
+          )(p => ZIO.log(s"Closing plugin manager") *> ZIO.succeed(p.close()))
         } <* ZIO.when(plugins.nonEmpty)(ZIO.log(s"Plugins loaded: ${plugins.map(_.name).mkString(", ")}"))
     }
   )

--- a/modules/explorer-core/src/main/scala/org/ergoplatform/uexplorer/chain/ChainLinker.scala
+++ b/modules/explorer-core/src/main/scala/org/ergoplatform/uexplorer/chain/ChainLinker.scala
@@ -1,22 +1,16 @@
 package org.ergoplatform.uexplorer.chain
 
-import eu.timepit.refined.auto.*
 import org.ergoplatform.uexplorer.*
 import org.ergoplatform.uexplorer.chain.ChainTip.FifoLinkedHashMap
 import org.ergoplatform.uexplorer.db.*
-import org.ergoplatform.uexplorer.node.{ApiFullBlock, ApiHeader}
-import org.ergoplatform.{ErgoAddressEncoder, ErgoScriptPredef, Pay2SAddress}
-import scorex.util.encode.Base16
-import sigmastate.basics.DLogProtocol.ProveDlog
-import sigmastate.serialization.{GroupElementSerializer, SigmaSerializer}
+import org.ergoplatform.uexplorer.node.ApiFullBlock
 import zio.*
+
 import java.util
-import scala.collection.immutable.TreeSet
-import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
-import scala.util.{Failure, Success, Try}
 
 class ChainTip(byBlockId: FifoLinkedHashMap[BlockId, Block]) {
+  def latestBlock: Option[Block] = toMap.values.toSeq.sortBy(_.height).lastOption
   def toMap: Map[BlockId, Block] = byBlockId.asScala.toMap
   def getParent(block: ApiFullBlock): Option[Block] =
     Option(byBlockId.get(block.header.parentId)).filter(_.height == block.header.height - 1)

--- a/modules/node-pool/src/main/scala/org/ergoplatform/uexplorer/http/UnderlyingBackend.scala
+++ b/modules/node-pool/src/main/scala/org/ergoplatform/uexplorer/http/UnderlyingBackend.scala
@@ -14,6 +14,8 @@ object UnderlyingBackend {
 
   def layerFor(backend: SttpBackendStub[Task, ZioStreams]): ZLayer[Any, Nothing, UnderlyingBackend] =
     ZLayer.scoped(
-      ZIO.acquireRelease(ZIO.succeed(UnderlyingBackend(backend)))(b => ZIO.succeed(b.backend.close()))
+      ZIO.acquireRelease(
+        ZIO.succeed(UnderlyingBackend(backend))
+      )(b => ZIO.log(s"Closing sttp backend") *> ZIO.succeed(b.backend.close()))
     )
 }

--- a/modules/node-pool/src/test/scala/org/ergoplatform/uexplorer/http/MetaHttpClientSpec.scala
+++ b/modules/node-pool/src/test/scala/org/ergoplatform/uexplorer/http/MetaHttpClientSpec.scala
@@ -1,24 +1,13 @@
 package org.ergoplatform.uexplorer.http
 
-import org.ergoplatform.uexplorer.config.ExplorerConfig
-import org.ergoplatform.uexplorer.http.{Rest, TestSupport}
 import sttp.client3.testing.SttpBackendStub
 import sttp.client3.*
 import sttp.model.StatusCode
-import org.ergoplatform.uexplorer.http.LocalNodeUriMagnet
-import org.ergoplatform.uexplorer.http.RemoteNodeUriMagnet
-import org.ergoplatform.uexplorer.http.MetadataHttpClient
-import org.ergoplatform.uexplorer.http.RemoteNode
-import org.ergoplatform.uexplorer.http.RemotePeer
-import org.ergoplatform.uexplorer.http.LocalNode
-import org.ergoplatform.uexplorer.http.RemotePeerUriMagnet
-import org.ergoplatform.uexplorer.http.ConnectedPeer
 import sttp.capabilities.zio.ZioStreams
 import zio.*
 import zio.test.*
 import zio.test.Assertion.*
 import sttp.client3.httpclient.zio.HttpClientZioBackend
-import zio.config.typesafe.TypesafeConfigProvider
 import zio.test.ZIOSpecDefault
 
 object MetaHttpClientSpec extends ZIOSpecDefault with TestSupport {
@@ -30,7 +19,9 @@ object MetaHttpClientSpec extends ZIOSpecDefault with TestSupport {
     fn: SttpBackendStub[Task, ZioStreams] => SttpBackendStub[Task, ZioStreams]
   ): ZLayer[Any, Throwable, MetadataHttpClient] =
     ZLayer.scoped(
-      ZIO.acquireRelease(ZIO.succeed(UnderlyingBackend(fn(HttpClientZioBackend.stub))))(b => ZIO.succeed(b.backend.close()))
+      ZIO.acquireRelease(
+        ZIO.succeed(UnderlyingBackend(fn(HttpClientZioBackend.stub)))
+      )(b => ZIO.log(s"Closing sttp backend stub") *> ZIO.succeed(b.backend.close()))
     ) ++ NodePoolConf.layer >>> MetadataHttpClient.layer
 
   def spec: Spec[Any, Throwable] =
@@ -82,9 +73,9 @@ object MetaHttpClientSpec extends ZIOSpecDefault with TestSupport {
         ZIO
           .serviceWithZIO[MetadataHttpClient] { client =>
             for {
-              conf <- NodePoolConf.configIO
-              f1   <- client.getConnectedPeers(LocalNode(conf.nodeAddressToInitFrom, appVersion, stateType, 839249)).fork
-              _    <- TestClock.adjust(2.minute)
+              conf           <- NodePoolConf.configIO
+              f1             <- client.getConnectedPeers(LocalNode(conf.nodeAddressToInitFrom, appVersion, stateType, 839249)).fork
+              _              <- TestClock.adjust(2.minute)
               connectedPeers <- f1.join
             } yield assertTrue(
               connectedPeers.collect { case ConnectedPeer(Some(restApiUrl)) => restApiUrl } == Set(uri"http://peer")

--- a/modules/node-pool/src/test/scala/org/ergoplatform/uexplorer/http/SttpNodePoolBackendSpec.scala
+++ b/modules/node-pool/src/test/scala/org/ergoplatform/uexplorer/http/SttpNodePoolBackendSpec.scala
@@ -40,7 +40,9 @@ object SttpNodePoolBackendSpec extends ZIOSpecDefault with TestSupport {
     fn: SttpBackendStub[Task, ZioStreams] => SttpBackendStub[Task, ZioStreams]
   ): ZLayer[Any, Throwable, NodePool with SttpNodePoolBackend] =
     ZLayer.scoped(
-      ZIO.acquireRelease(ZIO.succeed(UnderlyingBackend(fn(HttpClientZioBackend.stub))))(b => ZIO.succeed(b.backend.close()))
+      ZIO.acquireRelease(
+        ZIO.succeed(UnderlyingBackend(fn(HttpClientZioBackend.stub)))
+      )(b => ZIO.log(s"Closing sttp backend stub") *> ZIO.succeed(b.backend.close()))
     ) >+> NodePoolConf.layer >+> MetadataHttpClient.layer >+> NodePool.layer >+> SttpNodePoolBackend.layer
 
   def spec =


### PR DESCRIPTION
Fatal exceptions like OOM error can leave DB in corrupted state which requires reindexing ... this might save the day but it is not really 100% efficient 