### PR TITLE
resiliency enhancements at nodepool/http layer

### DIFF
--- a/modules/chain-indexer/src/main/scala/org/ergoplatform/uexplorer/indexer/StreamScheduler.scala
+++ b/modules/chain-indexer/src/main/scala/org/ergoplatform/uexplorer/indexer/StreamScheduler.scala
@@ -43,13 +43,13 @@ case class StreamScheduler(
         for {
           _         <- ZIO.log(s"Chain is empty, loading from scratch ...")
           poolFiber <- nodePoolBackend.keepNodePoolUpdated
-          _         <- periodicSync.repeat(schedule)
+          _         <- periodicSync.repeat(schedule).ignore
         } yield poolFiber
 
       case ChainValid =>
         for {
           poolFiber <- nodePoolBackend.keepNodePoolUpdated
-          _         <- periodicSync.repeat(schedule)
+          _         <- periodicSync.repeat(schedule).ignore
         } yield poolFiber
     }
 }


### PR DESCRIPTION
App should survive and be running even if 
 - there is no functional peer around
 - if we get `BlockId X` from `peer A` which suddenly dies and `fallback-peer B` does not have `Block X` yet
 