### PR TITLE
Proxy rest-api requests to node

### DIFF
--- a/modules/backend/src/main/scala/org/ergoplatform/uexplorer/backend/ProxyZioRoutes.scala
+++ b/modules/backend/src/main/scala/org/ergoplatform/uexplorer/backend/ProxyZioRoutes.scala
@@ -1,0 +1,16 @@
+package org.ergoplatform.uexplorer.backend
+
+import org.ergoplatform.uexplorer.http.NodePool
+import zio.*
+import zio.http.*
+
+object ProxyZioRoutes extends ZioRoutes with Codecs:
+
+  def apply(): Http[Client with NodePool, Throwable, Request, Response] =
+    Http.collectZIO[Request] { case req =>
+      for
+        bestPeerOpt <- ZIO.serviceWithZIO[NodePool](_.getBestPeer)
+        bestPeer    <- bestPeerOpt.fold(ZIO.fail(new IllegalStateException(s"Peers unavailable in node pool")))(ZIO.succeed)
+        response    <- Client.request(req.copy(url = URL.fromURI(bestPeer.uri.toJavaUri).map(_.withPath(req.path)).get))
+      yield response
+    }

--- a/modules/backend/src/main/scala/org/ergoplatform/uexplorer/backend/TapirRoutes.scala
+++ b/modules/backend/src/main/scala/org/ergoplatform/uexplorer/backend/TapirRoutes.scala
@@ -9,6 +9,9 @@ import zio.RIO
 import sttp.tapir.ztapir.*
 import zio.http.*
 
+trait TapirRoutes:
+  def rootPath = "explorer"
+
 object TapirRoutes extends BlockTapirRoutes with BoxTapirRoutes:
 
   val blockSwaggerEndpoints = List(infoEndpoint, blockByIdEndpoint, blockByIdsEndpoint)

--- a/modules/backend/src/main/scala/org/ergoplatform/uexplorer/backend/ZioRoutes.scala
+++ b/modules/backend/src/main/scala/org/ergoplatform/uexplorer/backend/ZioRoutes.scala
@@ -1,0 +1,36 @@
+package org.ergoplatform.uexplorer.backend
+
+import org.ergoplatform.uexplorer.CoreConf
+import org.ergoplatform.uexplorer.backend.blocks.{BlockRoutes, BlockService, PersistentBlockRepo}
+import org.ergoplatform.uexplorer.backend.boxes.{BoxRoutes, BoxService, PersistentBoxRepo}
+import org.ergoplatform.uexplorer.http.{NodePool, NodePoolConf}
+import zio.{Task, ZIO}
+import zio.http.*
+import zio.json.*
+
+trait ZioRoutes:
+  val rootPath = "explorer"
+
+  val tapirWithProxyRoutes: App[Client with NodePool with BoxService with BlockService] =
+    (TapirRoutes.routes ++ ProxyZioRoutes()).withDefaultErrorResponse
+
+  val zioHttpWithProxyRoutes: App[Client with NodePool with BoxService with BlockService] =
+    (BlockRoutes() ++ BoxRoutes() ++ ProxyZioRoutes()).withDefaultErrorResponse
+
+  val routeLayers =
+    Client.default >+>
+      CoreConf.layer >+>
+      NodePoolConf.layer >+>
+      NodePool.layerInitializedFromConf >+>
+      H2Backend.zLayerFromConf >+>
+      PersistentBoxRepo.layer >+>
+      PersistentBlockRepo.layer >+>
+      BoxService.layer >+>
+      BlockService.layer
+
+  def throwableToErrorResponse(t: Throwable): Task[Response] = t match {
+    case IdParsingException(_, msg) =>
+      ZIO.attempt(Response.json(ErrorResponse(Status.BadRequest.code, msg).toJson).withStatus(Status.BadRequest))
+    case e: Throwable =>
+      ZIO.attempt(Response.json(ErrorResponse(Status.InternalServerError.code, e.getMessage).toJson).withStatus(Status.InternalServerError))
+  }

--- a/modules/backend/src/main/scala/org/ergoplatform/uexplorer/backend/blocks/BlockTapirRoutes.scala
+++ b/modules/backend/src/main/scala/org/ergoplatform/uexplorer/backend/blocks/BlockTapirRoutes.scala
@@ -2,20 +2,20 @@ package org.ergoplatform.uexplorer.backend.blocks
 
 import org.ergoplatform.uexplorer.{Address, BlockId}
 import org.ergoplatform.uexplorer.db.Block
-import zio._
+import zio.*
 import sttp.tapir.{PublicEndpoint, Schema}
 import sttp.tapir.generic.auto.*
 import sttp.tapir.ztapir.*
 import sttp.tapir.json.zio.*
-import org.ergoplatform.uexplorer.backend.{Codecs, ErrorResponse}
+import org.ergoplatform.uexplorer.backend.{Codecs, ErrorResponse, TapirRoutes}
 import sttp.model.StatusCode
 import zio.json.{JsonDecoder, JsonEncoder}
 
-trait BlockTapirRoutes extends Codecs:
+trait BlockTapirRoutes extends TapirRoutes with Codecs:
 
   protected[backend] val infoEndpoint: PublicEndpoint[Unit, (ErrorResponse, StatusCode), Info, Any] =
-    endpoint.get
-      .in("info")
+    endpoint
+      .in(rootPath / "info")
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
       .out(jsonBody[Info])
@@ -37,7 +37,7 @@ trait BlockTapirRoutes extends Codecs:
 
   protected[backend] val blockByIdEndpoint: PublicEndpoint[String, (ErrorResponse, StatusCode), Block, Any] =
     endpoint.get
-      .in("blocks" / path[String]("blockId"))
+      .in(rootPath / "blocks" / path[String]("blockId"))
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
       .out(jsonBody[Block])
@@ -57,7 +57,7 @@ trait BlockTapirRoutes extends Codecs:
 
   protected[backend] val blockByIdsEndpoint: PublicEndpoint[Set[String], (ErrorResponse, StatusCode), List[Block], Any] =
     endpoint.post
-      .in("blocks")
+      .in(rootPath / "blocks")
       .in(jsonBody[Set[String]])
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)

--- a/modules/backend/src/main/scala/org/ergoplatform/uexplorer/backend/boxes/BoxRoutes.scala
+++ b/modules/backend/src/main/scala/org/ergoplatform/uexplorer/backend/boxes/BoxRoutes.scala
@@ -1,91 +1,84 @@
 package org.ergoplatform.uexplorer.backend.boxes
 
-import org.ergoplatform.uexplorer.backend.{Codecs, ErrorResponse, IdParsingException}
+import org.ergoplatform.uexplorer.backend.{Codecs, ErrorResponse, IdParsingException, ZioRoutes}
 import zio.*
 import zio.http.*
 import zio.json.*
 
-object BoxRoutes extends Codecs:
-
-  def throwableToErrorResponse(t: Throwable): Task[Response] = t match {
-    case IdParsingException(_, msg) =>
-      ZIO.attempt(Response.json(ErrorResponse(Status.BadRequest.code, msg).toJson).withStatus(Status.BadRequest))
-    case e: Throwable =>
-      ZIO.attempt(Response.json(ErrorResponse(Status.InternalServerError.code, e.getMessage).toJson).withStatus(Status.InternalServerError))
-  }
+object BoxRoutes extends ZioRoutes with Codecs:
 
   def apply(): Http[BoxService, Throwable, Request, Response] =
     Http.collectZIO[Request] {
-      case req @ Method.GET -> Root / "assets" / "unspent" / "by-token-id" / tokenId =>
+      case req @ Method.GET -> Root / rootPath / "assets" / "unspent" / "by-token-id" / tokenId =>
         BoxService
           .getUnspentAssetsByTokenId(tokenId, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(assets => Response.json(assets.toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "assets" / "spent" / "by-token-id" / tokenId =>
+      case req @ Method.GET -> Root / rootPath / "assets" / "spent" / "by-token-id" / tokenId =>
         BoxService
           .getSpentAssetsByTokenId(tokenId, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(assets => Response.json(assets.toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "assets" / "any" / "by-token-id" / tokenId =>
+      case req @ Method.GET -> Root / rootPath / "assets" / "any" / "by-token-id" / tokenId =>
         BoxService
           .getAnyAssetsByTokenId(tokenId, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(assets => Response.json(assets.toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "boxes" / "unspent" / "by-token-id" / tokenId =>
+      case req @ Method.GET -> Root / rootPath / "boxes" / "unspent" / "by-token-id" / tokenId =>
         BoxService
           .getUnspentBoxesByTokenId(tokenId, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(utxos => Response.json(utxos.toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "box-ids" / "unspent" / "by-token-id" / tokenId =>
+      case req @ Method.GET -> Root / rootPath / "box-ids" / "unspent" / "by-token-id" / tokenId =>
         BoxService
           .getUnspentBoxesByTokenId(tokenId, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(utxos => Response.json(utxos.map(_.boxId).toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "boxes" / "spent" / "by-token-id" / tokenId =>
+      case req @ Method.GET -> Root / rootPath / "boxes" / "spent" / "by-token-id" / tokenId =>
         BoxService
           .getSpentBoxesByTokenId(tokenId, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(boxes => Response.json(boxes.toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "box-ids" / "spent" / "by-token-id" / tokenId =>
+      case req @ Method.GET -> Root / rootPath / "box-ids" / "spent" / "by-token-id" / tokenId =>
         BoxService
           .getSpentBoxesByTokenId(tokenId, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(boxes => Response.json(boxes.map(_.boxId).toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "boxes" / "any" / "by-token-id" / tokenId =>
+      case req @ Method.GET -> Root / rootPath / "boxes" / "any" / "by-token-id" / tokenId =>
         BoxService
           .getAnyBoxesByTokenId(tokenId, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(boxes => Response.json(boxes.toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "box-ids" / "any" / "by-token-id" / tokenId =>
+      case req @ Method.GET -> Root / rootPath / "box-ids" / "any" / "by-token-id" / tokenId =>
         BoxService
           .getAnyBoxesByTokenId(tokenId, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(boxes => Response.json(boxes.map(_.boxId).toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case Method.GET -> Root / "boxes" / "unspent" / boxId =>
+      case Method.GET -> Root / rootPath / "boxes" / "unspent" / boxId =>
         BoxService
           .getUtxo(boxId)
           .map(_.fold(Response.status(Status.NotFound))(box => Response.json(box.toJson)))
           .orDie
 
-      case req @ Method.POST -> Root / "boxes" / "unspent" =>
+      case req @ Method.POST -> Root / rootPath / "boxes" / "unspent" =>
         (for {
           u <- req.body.asString.map(_.fromJson[Set[String]])
           r <- u.fold(
@@ -94,13 +87,13 @@ object BoxRoutes extends Codecs:
                )
         } yield r).orDie
 
-      case Method.GET -> Root / "boxes" / "spent" / boxId =>
+      case Method.GET -> Root / rootPath / "boxes" / "spent" / boxId =>
         BoxService
           .getSpentBox(boxId)
           .map(_.fold(Response.status(Status.NotFound))(box => Response.json(box.toJson)))
           .orDie
 
-      case req @ Method.POST -> Root / "boxes" / "spent" =>
+      case req @ Method.POST -> Root / rootPath / "boxes" / "spent" =>
         (for {
           u <- req.body.asString.map(_.fromJson[Set[String]])
           r <- u.fold(
@@ -109,13 +102,13 @@ object BoxRoutes extends Codecs:
                )
         } yield r).orDie
 
-      case Method.GET -> Root / "boxes" / "any" / boxId =>
+      case Method.GET -> Root / rootPath / "boxes" / "any" / boxId =>
         BoxService
           .getAnyBox(boxId)
           .map(_.fold(Response.status(Status.NotFound))(box => Response.json(box.toJson)))
           .orDie
 
-      case req @ Method.POST -> Root / "boxes" / "any" =>
+      case req @ Method.POST -> Root / rootPath / "boxes" / "any" =>
         (for {
           u <- req.body.asString.map(_.fromJson[Set[String]])
           r <- u.fold(
@@ -124,210 +117,210 @@ object BoxRoutes extends Codecs:
                )
         } yield r).orDie
 
-      case req @ Method.GET -> Root / "boxes" / "spent" / "by-address" / address =>
+      case req @ Method.GET -> Root / rootPath / "boxes" / "spent" / "by-address" / address =>
         BoxService
           .getSpentBoxesByAddress(address, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(boxes => Response.json(boxes.toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "box-ids" / "spent" / "by-address" / address =>
+      case req @ Method.GET -> Root / rootPath / "box-ids" / "spent" / "by-address" / address =>
         BoxService
           .getSpentBoxesByAddress(address, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(boxes => Response.json(boxes.map(_.boxId).toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "boxes" / "unspent" / "by-address" / address =>
+      case req @ Method.GET -> Root / rootPath / "boxes" / "unspent" / "by-address" / address =>
         BoxService
           .getUnspentBoxesByAddress(address, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(utxos => Response.json(utxos.toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "box-ids" / "unspent" / "by-address" / address =>
+      case req @ Method.GET -> Root / rootPath / "box-ids" / "unspent" / "by-address" / address =>
         BoxService
           .getUnspentBoxesByAddress(address, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(utxos => Response.json(utxos.map(_.boxId).toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "boxes" / "any" / "by-address" / address =>
+      case req @ Method.GET -> Root / rootPath / "boxes" / "any" / "by-address" / address =>
         BoxService
           .getAnyBoxesByAddress(address, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(boxes => Response.json(boxes.toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "box-ids" / "any" / "by-address" / address =>
+      case req @ Method.GET -> Root / rootPath / "box-ids" / "any" / "by-address" / address =>
         BoxService
           .getAnyBoxesByAddress(address, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(boxes => Response.json(boxes.map(_.boxId).toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "boxes" / "spent" / "contracts" / "by-ergo-tree" / ergoTree =>
+      case req @ Method.GET -> Root / rootPath / "boxes" / "spent" / "contracts" / "by-ergo-tree" / ergoTree =>
         BoxService
           .getSpentBoxesByErgoTree(ergoTree, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(boxes => Response.json(boxes.toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "box-ids" / "spent" / "contracts" / "by-ergo-tree" / ergoTree =>
+      case req @ Method.GET -> Root / rootPath / "box-ids" / "spent" / "contracts" / "by-ergo-tree" / ergoTree =>
         BoxService
           .getSpentBoxesByErgoTree(ergoTree, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(boxes => Response.json(boxes.map(_.boxId).toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "boxes" / "unspent" / "contracts" / "by-ergo-tree" / ergoTree =>
+      case req @ Method.GET -> Root / rootPath / "boxes" / "unspent" / "contracts" / "by-ergo-tree" / ergoTree =>
         BoxService
           .getUnspentBoxesByErgoTree(ergoTree, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(utxos => Response.json(utxos.toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "box-ids" / "unspent" / "contracts" / "by-ergo-tree" / ergoTree =>
+      case req @ Method.GET -> Root / rootPath / "box-ids" / "unspent" / "contracts" / "by-ergo-tree" / ergoTree =>
         BoxService
           .getUnspentBoxesByErgoTree(ergoTree, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(utxos => Response.json(utxos.map(_.boxId).toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "boxes" / "any" / "contracts" / "by-ergo-tree" / ergoTree =>
+      case req @ Method.GET -> Root / rootPath / "boxes" / "any" / "contracts" / "by-ergo-tree" / ergoTree =>
         BoxService
           .getAnyBoxesByErgoTree(ergoTree, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(boxes => Response.json(boxes.toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "box-ids" / "any" / "contracts" / "by-ergo-tree" / ergoTree =>
+      case req @ Method.GET -> Root / rootPath / "box-ids" / "any" / "contracts" / "by-ergo-tree" / ergoTree =>
         BoxService
           .getAnyBoxesByErgoTree(ergoTree, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(boxes => Response.json(boxes.map(_.boxId).toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "boxes" / "spent" / "contracts" / "by-ergo-tree-hash" / ergoTreeHash =>
+      case req @ Method.GET -> Root / rootPath / "boxes" / "spent" / "contracts" / "by-ergo-tree-hash" / ergoTreeHash =>
         BoxService
           .getSpentBoxesByErgoTreeHash(ergoTreeHash, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(boxes => Response.json(boxes.toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "box-ids" / "spent" / "contracts" / "by-ergo-tree-hash" / ergoTreeHash =>
+      case req @ Method.GET -> Root / rootPath / "box-ids" / "spent" / "contracts" / "by-ergo-tree-hash" / ergoTreeHash =>
         BoxService
           .getSpentBoxesByErgoTreeHash(ergoTreeHash, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(boxes => Response.json(boxes.map(_.boxId).toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "boxes" / "unspent" / "contracts" / "by-ergo-tree-hash" / ergoTreeHash =>
+      case req @ Method.GET -> Root / rootPath / "boxes" / "unspent" / "contracts" / "by-ergo-tree-hash" / ergoTreeHash =>
         BoxService
           .getUnspentBoxesByErgoTreeHash(ergoTreeHash, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(utxos => Response.json(utxos.toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "box-ids" / "unspent" / "contracts" / "by-ergo-tree-hash" / ergoTreeHash =>
+      case req @ Method.GET -> Root / rootPath / "box-ids" / "unspent" / "contracts" / "by-ergo-tree-hash" / ergoTreeHash =>
         BoxService
           .getUnspentBoxesByErgoTreeHash(ergoTreeHash, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(utxos => Response.json(utxos.map(_.boxId).toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "boxes" / "any" / "contracts" / "by-ergo-tree-hash" / ergoTreeHash =>
+      case req @ Method.GET -> Root / rootPath / "boxes" / "any" / "contracts" / "by-ergo-tree-hash" / ergoTreeHash =>
         BoxService
           .getAnyBoxesByErgoTreeHash(ergoTreeHash, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(boxes => Response.json(boxes.toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "box-ids" / "any" / "contracts" / "by-ergo-tree-hash" / ergoTreeHash =>
+      case req @ Method.GET -> Root / rootPath / "box-ids" / "any" / "contracts" / "by-ergo-tree-hash" / ergoTreeHash =>
         BoxService
           .getAnyBoxesByErgoTreeHash(ergoTreeHash, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(boxes => Response.json(boxes.map(_.boxId).toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "boxes" / "spent" / "templates" / "by-ergo-tree" / ergoTreeT8 =>
+      case req @ Method.GET -> Root / rootPath / "boxes" / "spent" / "templates" / "by-ergo-tree" / ergoTreeT8 =>
         BoxService
           .getSpentBoxesByErgoTreeT8(ergoTreeT8, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(boxes => Response.json(boxes.toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "box-ids" / "spent" / "templates" / "by-ergo-tree" / ergoTreeT8 =>
+      case req @ Method.GET -> Root / rootPath / "box-ids" / "spent" / "templates" / "by-ergo-tree" / ergoTreeT8 =>
         BoxService
           .getSpentBoxesByErgoTreeT8(ergoTreeT8, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(boxes => Response.json(boxes.map(_.boxId).toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "boxes" / "unspent" / "templates" / "by-ergo-tree" / ergoTreeT8 =>
+      case req @ Method.GET -> Root / rootPath / "boxes" / "unspent" / "templates" / "by-ergo-tree" / ergoTreeT8 =>
         BoxService
           .getUnspentBoxesByErgoTreeT8(ergoTreeT8, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(utxos => Response.json(utxos.toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "box-ids" / "unspent" / "templates" / "by-ergo-tree" / ergoTreeT8 =>
+      case req @ Method.GET -> Root / rootPath / "box-ids" / "unspent" / "templates" / "by-ergo-tree" / ergoTreeT8 =>
         BoxService
           .getUnspentBoxesByErgoTreeT8(ergoTreeT8, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(utxos => Response.json(utxos.map(_.boxId).toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "boxes" / "any" / "templates" / "by-ergo-tree" / ergoTreeT8 =>
+      case req @ Method.GET -> Root / rootPath / "boxes" / "any" / "templates" / "by-ergo-tree" / ergoTreeT8 =>
         BoxService
           .getAnyBoxesByErgoTreeT8(ergoTreeT8, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(boxes => Response.json(boxes.toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "box-ids" / "any" / "templates" / "by-ergo-tree" / ergoTreeT8 =>
+      case req @ Method.GET -> Root / rootPath / "box-ids" / "any" / "templates" / "by-ergo-tree" / ergoTreeT8 =>
         BoxService
           .getAnyBoxesByErgoTreeT8(ergoTreeT8, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(boxes => Response.json(boxes.map(_.boxId).toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "boxes" / "spent" / "templates" / "by-ergo-tree-hash" / ergoTreeT8Hash =>
+      case req @ Method.GET -> Root / rootPath / "boxes" / "spent" / "templates" / "by-ergo-tree-hash" / ergoTreeT8Hash =>
         BoxService
           .getSpentBoxesByErgoTreeT8Hash(ergoTreeT8Hash, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(boxes => Response.json(boxes.toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "box-ids" / "spent" / "templates" / "by-ergo-tree-hash" / ergoTreeT8Hash =>
+      case req @ Method.GET -> Root / rootPath / "box-ids" / "spent" / "templates" / "by-ergo-tree-hash" / ergoTreeT8Hash =>
         BoxService
           .getSpentBoxesByErgoTreeT8Hash(ergoTreeT8Hash, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(boxes => Response.json(boxes.map(_.boxId).toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "boxes" / "unspent" / "templates" / "by-ergo-tree-hash" / ergoTreeT8Hash =>
+      case req @ Method.GET -> Root / rootPath / "boxes" / "unspent" / "templates" / "by-ergo-tree-hash" / ergoTreeT8Hash =>
         BoxService
           .getUnspentBoxesByErgoTreeT8Hash(ergoTreeT8Hash, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(utxos => Response.json(utxos.toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "box-ids" / "unspent" / "templates" / "by-ergo-tree-hash" / ergoTreeT8Hash =>
+      case req @ Method.GET -> Root / rootPath / "box-ids" / "unspent" / "templates" / "by-ergo-tree-hash" / ergoTreeT8Hash =>
         BoxService
           .getUnspentBoxesByErgoTreeT8Hash(ergoTreeT8Hash, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(utxos => Response.json(utxos.map(_.boxId).toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "boxes" / "any" / "templates" / "by-ergo-tree-hash" / ergoTreeT8Hash =>
+      case req @ Method.GET -> Root / rootPath / "boxes" / "any" / "templates" / "by-ergo-tree-hash" / ergoTreeT8Hash =>
         BoxService
           .getAnyBoxesByErgoTreeT8Hash(ergoTreeT8Hash, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(boxes => Response.json(boxes.toJson))
           .catchAllDefect(throwableToErrorResponse)
           .orDie
 
-      case req @ Method.GET -> Root / "box-ids" / "any" / "templates" / "by-ergo-tree-hash" / ergoTreeT8Hash =>
+      case req @ Method.GET -> Root / rootPath / "box-ids" / "any" / "templates" / "by-ergo-tree-hash" / ergoTreeT8Hash =>
         BoxService
           .getAnyBoxesByErgoTreeT8Hash(ergoTreeT8Hash, req.url.queryParams.map.view.mapValues(_.head).toMap)
           .map(boxes => Response.json(boxes.map(_.boxId).toJson))

--- a/modules/backend/src/main/scala/org/ergoplatform/uexplorer/backend/boxes/BoxesByAddress.scala
+++ b/modules/backend/src/main/scala/org/ergoplatform/uexplorer/backend/boxes/BoxesByAddress.scala
@@ -1,28 +1,21 @@
 package org.ergoplatform.uexplorer.backend.boxes
 
-import org.ergoplatform.uexplorer.BlockId.unwrapped
-import org.ergoplatform.uexplorer.BoxId.unwrapped
-import org.ergoplatform.uexplorer.backend.{Codecs, ErrorResponse}
-import org.ergoplatform.uexplorer.db.{Asset2Box, Block, Box, Utxo}
-import org.ergoplatform.uexplorer.{Address, BlockId, BoxId, TxId}
+import org.ergoplatform.uexplorer.backend.{Codecs, ErrorResponse, TapirRoutes}
+import org.ergoplatform.uexplorer.db.{Box, Utxo}
+import org.ergoplatform.uexplorer.{BlockId, BoxId, TxId}
 import sttp.model.{QueryParams, StatusCode}
 import sttp.tapir.generic.auto.*
 import sttp.tapir.json.zio.*
-import sttp.tapir.server.ServerEndpoint
-import sttp.tapir.server.ziohttp.ZioHttpInterpreter
-import sttp.tapir.swagger.bundle.SwaggerInterpreter
 import sttp.tapir.ztapir.*
 import sttp.tapir.{queryParams, PublicEndpoint, Schema}
-import zio.http.{HttpApp, Server}
-import zio.json.*
 import zio.*
-import org.ergoplatform.uexplorer.backend.IdParsingException
+import zio.json.*
 
-trait BoxesByAddress extends Codecs:
+trait BoxesByAddress extends TapirRoutes with Codecs:
 
   protected[backend] val spentBoxesByAddress: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[Box], Any] =
     endpoint.get
-      .in("boxes" / "spent" / "by-address" / path[String]("address"))
+      .in(rootPath / "boxes" / "spent" / "by-address" / path[String]("address"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
@@ -38,7 +31,7 @@ trait BoxesByAddress extends Codecs:
 
   protected[backend] val spentBoxIdsByAddress: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[BoxId], Any] =
     endpoint.get
-      .in("box-ids" / "spent" / "by-address" / path[String]("address"))
+      .in(rootPath / "box-ids" / "spent" / "by-address" / path[String]("address"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
@@ -55,7 +48,7 @@ trait BoxesByAddress extends Codecs:
 
   protected[backend] val unspentBoxesByAddress: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[Utxo], Any] =
     endpoint.get
-      .in("boxes" / "unspent" / "by-address" / path[String]("address"))
+      .in(rootPath / "boxes" / "unspent" / "by-address" / path[String]("address"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
@@ -72,7 +65,7 @@ trait BoxesByAddress extends Codecs:
 
   protected[backend] val unspentBoxIdsByAddress: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[BoxId], Any] =
     endpoint.get
-      .in("box-ids" / "unspent" / "by-address" / path[String]("address"))
+      .in(rootPath / "box-ids" / "unspent" / "by-address" / path[String]("address"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
@@ -89,7 +82,7 @@ trait BoxesByAddress extends Codecs:
 
   protected[backend] val anyBoxesByAddress: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[Box], Any] =
     endpoint.get
-      .in("boxes" / "any" / "by-address" / path[String]("address"))
+      .in(rootPath / "boxes" / "any" / "by-address" / path[String]("address"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
@@ -105,7 +98,7 @@ trait BoxesByAddress extends Codecs:
 
   protected[backend] val anyBoxIdsByAddress: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[BoxId], Any] =
     endpoint.get
-      .in("box-ids" / "any" / "by-address" / path[String]("address"))
+      .in(rootPath / "box-ids" / "any" / "by-address" / path[String]("address"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)

--- a/modules/backend/src/main/scala/org/ergoplatform/uexplorer/backend/boxes/BoxesByErgoTree.scala
+++ b/modules/backend/src/main/scala/org/ergoplatform/uexplorer/backend/boxes/BoxesByErgoTree.scala
@@ -1,28 +1,21 @@
 package org.ergoplatform.uexplorer.backend.boxes
 
-import org.ergoplatform.uexplorer.BlockId.unwrapped
-import org.ergoplatform.uexplorer.BoxId.unwrapped
-import org.ergoplatform.uexplorer.backend.{Codecs, ErrorResponse}
-import org.ergoplatform.uexplorer.db.{Asset2Box, Block, Box, Utxo}
-import org.ergoplatform.uexplorer.{Address, BlockId, BoxId, TxId}
+import org.ergoplatform.uexplorer.backend.{Codecs, ErrorResponse, TapirRoutes}
+import org.ergoplatform.uexplorer.db.{Box, Utxo}
+import org.ergoplatform.uexplorer.{BlockId, BoxId, TxId}
 import sttp.model.{QueryParams, StatusCode}
 import sttp.tapir.generic.auto.*
 import sttp.tapir.json.zio.*
-import sttp.tapir.server.ServerEndpoint
-import sttp.tapir.server.ziohttp.ZioHttpInterpreter
-import sttp.tapir.swagger.bundle.SwaggerInterpreter
 import sttp.tapir.ztapir.*
-import sttp.tapir.{queryParams, PublicEndpoint, Schema}
-import zio.http.{HttpApp, Server}
-import zio.json.*
+import sttp.tapir.{PublicEndpoint, Schema, queryParams}
 import zio.*
-import org.ergoplatform.uexplorer.backend.IdParsingException
+import zio.json.*
 
-trait BoxesByErgoTree extends Codecs:
+trait BoxesByErgoTree extends TapirRoutes with Codecs:
 
   protected[backend] val spentContractBoxesByErgoTree: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[Box], Any] =
     endpoint.get
-      .in("boxes" / "spent" / "contracts" / "by-ergo-tree" / path[String]("ergoTree"))
+      .in(rootPath / "boxes" / "spent" / "contracts" / "by-ergo-tree" / path[String]("ergoTree"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
@@ -38,7 +31,7 @@ trait BoxesByErgoTree extends Codecs:
 
   protected[backend] val spentContractBoxIdsByErgoTree: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[BoxId], Any] =
     endpoint.get
-      .in("box-ids" / "spent" / "contracts" / "by-ergo-tree" / path[String]("ergoTree"))
+      .in(rootPath / "box-ids" / "spent" / "contracts" / "by-ergo-tree" / path[String]("ergoTree"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
@@ -55,7 +48,7 @@ trait BoxesByErgoTree extends Codecs:
 
   protected[backend] val unspentContractBoxesByErgoTree: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[Utxo], Any] =
     endpoint.get
-      .in("boxes" / "unspent" / "contracts" / "by-ergo-tree" / path[String]("ergoTree"))
+      .in(rootPath / "boxes" / "unspent" / "contracts" / "by-ergo-tree" / path[String]("ergoTree"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
@@ -71,7 +64,7 @@ trait BoxesByErgoTree extends Codecs:
 
   protected[backend] val unspentContractBoxIdsByErgoTree: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[BoxId], Any] =
     endpoint.get
-      .in("box-ids" / "unspent" / "contracts" / "by-ergo-tree" / path[String]("ergoTree"))
+      .in(rootPath / "box-ids" / "unspent" / "contracts" / "by-ergo-tree" / path[String]("ergoTree"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
@@ -88,7 +81,7 @@ trait BoxesByErgoTree extends Codecs:
 
   protected[backend] val anyContractBoxesByErgoTree: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[Box], Any] =
     endpoint.get
-      .in("boxes" / "any" / "contracts" / "by-ergo-tree" / path[String]("ergoTree"))
+      .in(rootPath / "boxes" / "any" / "contracts" / "by-ergo-tree" / path[String]("ergoTree"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
@@ -104,7 +97,7 @@ trait BoxesByErgoTree extends Codecs:
 
   protected[backend] val anyContractBoxIdsByErgoTree: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[BoxId], Any] =
     endpoint.get
-      .in("box-ids" / "any" / "contracts" / "by-ergo-tree" / path[String]("ergoTree"))
+      .in(rootPath / "box-ids" / "any" / "contracts" / "by-ergo-tree" / path[String]("ergoTree"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)

--- a/modules/backend/src/main/scala/org/ergoplatform/uexplorer/backend/boxes/BoxesByErgoTreeHash.scala
+++ b/modules/backend/src/main/scala/org/ergoplatform/uexplorer/backend/boxes/BoxesByErgoTreeHash.scala
@@ -1,28 +1,21 @@
 package org.ergoplatform.uexplorer.backend.boxes
 
-import org.ergoplatform.uexplorer.BlockId.unwrapped
-import org.ergoplatform.uexplorer.BoxId.unwrapped
-import org.ergoplatform.uexplorer.backend.{Codecs, ErrorResponse}
-import org.ergoplatform.uexplorer.db.{Asset2Box, Block, Box, Utxo}
-import org.ergoplatform.uexplorer.{Address, BlockId, BoxId, TxId}
+import org.ergoplatform.uexplorer.backend.{Codecs, ErrorResponse, TapirRoutes}
+import org.ergoplatform.uexplorer.db.{Box, Utxo}
+import org.ergoplatform.uexplorer.{BlockId, BoxId, TxId}
 import sttp.model.{QueryParams, StatusCode}
 import sttp.tapir.generic.auto.*
 import sttp.tapir.json.zio.*
-import sttp.tapir.server.ServerEndpoint
-import sttp.tapir.server.ziohttp.ZioHttpInterpreter
-import sttp.tapir.swagger.bundle.SwaggerInterpreter
 import sttp.tapir.ztapir.*
-import sttp.tapir.{queryParams, PublicEndpoint, Schema}
+import sttp.tapir.{PublicEndpoint, Schema, queryParams}
 import zio.*
-import zio.http.{HttpApp, Server}
 import zio.json.*
-import org.ergoplatform.uexplorer.backend.IdParsingException
 
-trait BoxesByErgoTreeHash extends Codecs:
+trait BoxesByErgoTreeHash extends TapirRoutes with Codecs:
 
   protected[backend] val spentContractBoxesByErgoTreeHash: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[Box], Any] =
     endpoint.get
-      .in("boxes" / "spent" / "contracts" / "by-ergo-tree-hash" / path[String]("ergoTreeHash"))
+      .in(rootPath / "boxes" / "spent" / "contracts" / "by-ergo-tree-hash" / path[String]("ergoTreeHash"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
@@ -38,7 +31,7 @@ trait BoxesByErgoTreeHash extends Codecs:
 
   protected[backend] val spentContractBoxIdsByErgoTreeHash: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[BoxId], Any] =
     endpoint.get
-      .in("box-ids" / "spent" / "contracts" / "by-ergo-tree-hash" / path[String]("ergoTreeHash"))
+      .in(rootPath / "box-ids" / "spent" / "contracts" / "by-ergo-tree-hash" / path[String]("ergoTreeHash"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
@@ -55,7 +48,7 @@ trait BoxesByErgoTreeHash extends Codecs:
 
   protected[backend] val unspentContractBoxesByErgoTreeHash: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[Utxo], Any] =
     endpoint.get
-      .in("boxes" / "unspent" / "contracts" / "by-ergo-tree-hash" / path[String]("ergoTreeHash"))
+      .in(rootPath / "boxes" / "unspent" / "contracts" / "by-ergo-tree-hash" / path[String]("ergoTreeHash"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
@@ -71,7 +64,7 @@ trait BoxesByErgoTreeHash extends Codecs:
 
   protected[backend] val unspentContractBoxIdsByErgoTreeHash: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[BoxId], Any] =
     endpoint.get
-      .in("box-ids" / "unspent" / "contracts" / "by-ergo-tree-hash" / path[String]("ergoTreeHash"))
+      .in(rootPath / "box-ids" / "unspent" / "contracts" / "by-ergo-tree-hash" / path[String]("ergoTreeHash"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
@@ -88,7 +81,7 @@ trait BoxesByErgoTreeHash extends Codecs:
 
   protected[backend] val anyContractBoxesByErgoTreeHash: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[Box], Any] =
     endpoint.get
-      .in("boxes" / "any" / "contracts" / "by-ergo-tree-hash" / path[String]("ergoTreeHash"))
+      .in(rootPath / "boxes" / "any" / "contracts" / "by-ergo-tree-hash" / path[String]("ergoTreeHash"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
@@ -104,7 +97,7 @@ trait BoxesByErgoTreeHash extends Codecs:
 
   protected[backend] val anyContractBoxIdsByErgoTreeHash: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[BoxId], Any] =
     endpoint.get
-      .in("box-ids" / "any" / "contracts" / "by-ergo-tree-hash" / path[String]("ergoTreeHash"))
+      .in(rootPath / "box-ids" / "any" / "contracts" / "by-ergo-tree-hash" / path[String]("ergoTreeHash"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)

--- a/modules/backend/src/main/scala/org/ergoplatform/uexplorer/backend/boxes/BoxesByErgoTreeTemplate.scala
+++ b/modules/backend/src/main/scala/org/ergoplatform/uexplorer/backend/boxes/BoxesByErgoTreeTemplate.scala
@@ -1,28 +1,21 @@
 package org.ergoplatform.uexplorer.backend.boxes
 
-import org.ergoplatform.uexplorer.BlockId.unwrapped
-import org.ergoplatform.uexplorer.BoxId.unwrapped
-import org.ergoplatform.uexplorer.backend.{Codecs, ErrorResponse}
-import org.ergoplatform.uexplorer.db.{Asset2Box, Block, Box, Utxo}
-import org.ergoplatform.uexplorer.{Address, BlockId, BoxId, TxId}
+import org.ergoplatform.uexplorer.backend.{Codecs, ErrorResponse, TapirRoutes}
+import org.ergoplatform.uexplorer.db.{Box, Utxo}
+import org.ergoplatform.uexplorer.{BoxId, TxId}
 import sttp.model.{QueryParams, StatusCode}
 import sttp.tapir.generic.auto.*
 import sttp.tapir.json.zio.*
-import sttp.tapir.server.ServerEndpoint
-import sttp.tapir.server.ziohttp.ZioHttpInterpreter
-import sttp.tapir.swagger.bundle.SwaggerInterpreter
 import sttp.tapir.ztapir.*
 import sttp.tapir.{queryParams, PublicEndpoint, Schema}
 import zio.*
-import zio.http.{HttpApp, Server}
 import zio.json.*
-import org.ergoplatform.uexplorer.backend.IdParsingException
 
-trait BoxesByErgoTreeTemplate extends Codecs:
+trait BoxesByErgoTreeTemplate extends TapirRoutes with Codecs:
 
   protected[backend] val spentTemplateBoxesByErgoTree: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[Box], Any] =
     endpoint.get
-      .in("boxes" / "spent" / "templates" / "by-ergo-tree" / path[String]("ergoTreeT8"))
+      .in(rootPath / "boxes" / "spent" / "templates" / "by-ergo-tree" / path[String]("ergoTreeT8"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
@@ -38,7 +31,7 @@ trait BoxesByErgoTreeTemplate extends Codecs:
 
   protected[backend] val spentTemplateBoxIdsByErgoTree: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[BoxId], Any] =
     endpoint.get
-      .in("box-ids" / "spent" / "templates" / "by-ergo-tree" / path[String]("ergoTreeT8"))
+      .in(rootPath / "box-ids" / "spent" / "templates" / "by-ergo-tree" / path[String]("ergoTreeT8"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
@@ -55,7 +48,7 @@ trait BoxesByErgoTreeTemplate extends Codecs:
 
   protected[backend] val unspentTemplateBoxesByErgoTree: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[Utxo], Any] =
     endpoint.get
-      .in("boxes" / "unspent" / "templates" / "by-ergo-tree" / path[String]("ergoTreeT8"))
+      .in(rootPath / "boxes" / "unspent" / "templates" / "by-ergo-tree" / path[String]("ergoTreeT8"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
@@ -71,7 +64,7 @@ trait BoxesByErgoTreeTemplate extends Codecs:
 
   protected[backend] val unspentTemplateBoxIdsByErgoTree: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[BoxId], Any] =
     endpoint.get
-      .in("box-ids" / "unspent" / "templates" / "by-ergo-tree" / path[String]("ergoTreeT8"))
+      .in(rootPath / "box-ids" / "unspent" / "templates" / "by-ergo-tree" / path[String]("ergoTreeT8"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
@@ -88,7 +81,7 @@ trait BoxesByErgoTreeTemplate extends Codecs:
 
   protected[backend] val anyTemplateBoxesByErgoTree: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[Box], Any] =
     endpoint.get
-      .in("boxes" / "any" / "templates" / "by-ergo-tree" / path[String]("ergoTreeT8"))
+      .in(rootPath / "boxes" / "any" / "templates" / "by-ergo-tree" / path[String]("ergoTreeT8"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
@@ -104,7 +97,7 @@ trait BoxesByErgoTreeTemplate extends Codecs:
 
   protected[backend] val anyTemplateBoxIdsByErgoTree: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[BoxId], Any] =
     endpoint.get
-      .in("box-ids" / "any" / "templates" / "by-ergo-tree" / path[String]("ergoTreeT8"))
+      .in(rootPath / "box-ids" / "any" / "templates" / "by-ergo-tree" / path[String]("ergoTreeT8"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)

--- a/modules/backend/src/main/scala/org/ergoplatform/uexplorer/backend/boxes/BoxesByErgoTreeTemplateHash.scala
+++ b/modules/backend/src/main/scala/org/ergoplatform/uexplorer/backend/boxes/BoxesByErgoTreeTemplateHash.scala
@@ -2,7 +2,7 @@ package org.ergoplatform.uexplorer.backend.boxes
 
 import org.ergoplatform.uexplorer.BlockId.unwrapped
 import org.ergoplatform.uexplorer.BoxId.unwrapped
-import org.ergoplatform.uexplorer.backend.{Codecs, ErrorResponse}
+import org.ergoplatform.uexplorer.backend.{Codecs, ErrorResponse, IdParsingException, TapirRoutes}
 import org.ergoplatform.uexplorer.db.{Asset2Box, Block, Box, Utxo}
 import org.ergoplatform.uexplorer.{Address, BlockId, BoxId, TxId}
 import sttp.model.{QueryParams, StatusCode}
@@ -16,13 +16,12 @@ import sttp.tapir.{queryParams, PublicEndpoint, Schema}
 import zio.*
 import zio.http.{HttpApp, Server}
 import zio.json.*
-import org.ergoplatform.uexplorer.backend.IdParsingException
 
-trait BoxesByErgoTreeTemplateHash extends Codecs:
+trait BoxesByErgoTreeTemplateHash extends TapirRoutes with Codecs:
 
   protected[backend] val spentTemplateBoxesByErgoTreeHash: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[Box], Any] =
     endpoint.get
-      .in("boxes" / "spent" / "templates" / "by-ergo-tree-hash" / path[String]("ergoTreeT8Hash"))
+      .in(rootPath / "boxes" / "spent" / "templates" / "by-ergo-tree-hash" / path[String]("ergoTreeT8Hash"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
@@ -38,7 +37,7 @@ trait BoxesByErgoTreeTemplateHash extends Codecs:
 
   protected[backend] val spentTemplateBoxIdsByErgoTreeHash: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[BoxId], Any] =
     endpoint.get
-      .in("box-ids" / "spent" / "templates" / "by-ergo-tree-hash" / path[String]("ergoTreeT8Hash"))
+      .in(rootPath / "box-ids" / "spent" / "templates" / "by-ergo-tree-hash" / path[String]("ergoTreeT8Hash"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
@@ -55,7 +54,7 @@ trait BoxesByErgoTreeTemplateHash extends Codecs:
 
   protected[backend] val unspentTemplateBoxesByErgoTreeHash: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[Utxo], Any] =
     endpoint.get
-      .in("boxes" / "unspent" / "templates" / "by-ergo-tree-hash" / path[String]("ergoTreeT8Hash"))
+      .in(rootPath / "boxes" / "unspent" / "templates" / "by-ergo-tree-hash" / path[String]("ergoTreeT8Hash"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
@@ -71,7 +70,7 @@ trait BoxesByErgoTreeTemplateHash extends Codecs:
 
   protected[backend] val unspentTemplateBoxIdsByErgoTreeHash: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[BoxId], Any] =
     endpoint.get
-      .in("box-ids" / "unspent" / "templates" / "by-ergo-tree-hash" / path[String]("ergoTreeT8Hash"))
+      .in(rootPath / "box-ids" / "unspent" / "templates" / "by-ergo-tree-hash" / path[String]("ergoTreeT8Hash"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
@@ -89,7 +88,7 @@ trait BoxesByErgoTreeTemplateHash extends Codecs:
 
   protected[backend] val anyTemplateBoxesByErgoTreeHash: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[Box], Any] =
     endpoint.get
-      .in("boxes" / "any" / "templates" / "by-ergo-tree-hash" / path[String]("ergoTreeT8Hash"))
+      .in(rootPath / "boxes" / "any" / "templates" / "by-ergo-tree-hash" / path[String]("ergoTreeT8Hash"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
@@ -105,7 +104,7 @@ trait BoxesByErgoTreeTemplateHash extends Codecs:
 
   protected[backend] val anyTemplateBoxIdsByErgoTreeHash: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[BoxId], Any] =
     endpoint.get
-      .in("box-ids" / "any" / "templates" / "by-ergo-tree-hash" / path[String]("ergoTreeT8Hash"))
+      .in(rootPath / "box-ids" / "any" / "templates" / "by-ergo-tree-hash" / path[String]("ergoTreeT8Hash"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)

--- a/modules/backend/src/main/scala/org/ergoplatform/uexplorer/backend/boxes/BoxesByIdRoutes.scala
+++ b/modules/backend/src/main/scala/org/ergoplatform/uexplorer/backend/boxes/BoxesByIdRoutes.scala
@@ -1,28 +1,21 @@
 package org.ergoplatform.uexplorer.backend.boxes
 
-import org.ergoplatform.uexplorer.BlockId.unwrapped
-import org.ergoplatform.uexplorer.BoxId.unwrapped
-import org.ergoplatform.uexplorer.backend.{Codecs, ErrorResponse}
-import org.ergoplatform.uexplorer.db.{Asset2Box, Block, Box, Utxo}
-import org.ergoplatform.uexplorer.{Address, BlockId, BoxId, TxId}
-import sttp.model.{QueryParams, StatusCode}
+import org.ergoplatform.uexplorer.backend.{Codecs, ErrorResponse, TapirRoutes}
+import org.ergoplatform.uexplorer.db.{Box, Utxo}
+import org.ergoplatform.uexplorer.{BlockId, BoxId, TxId}
+import sttp.model.StatusCode
 import sttp.tapir.generic.auto.*
 import sttp.tapir.json.zio.*
-import sttp.tapir.server.ServerEndpoint
-import sttp.tapir.server.ziohttp.ZioHttpInterpreter
-import sttp.tapir.swagger.bundle.SwaggerInterpreter
 import sttp.tapir.ztapir.*
-import sttp.tapir.{queryParams, PublicEndpoint, Schema}
-import zio.http.{HttpApp, Server}
-import zio.json.*
+import sttp.tapir.{PublicEndpoint, queryParams}
 import zio.*
-import org.ergoplatform.uexplorer.backend.IdParsingException
+import zio.json.*
 
-trait BoxesByIdRoutes extends Codecs:
+trait BoxesByIdRoutes extends TapirRoutes with Codecs:
 
   protected[backend] val unspentBoxById: PublicEndpoint[String, (ErrorResponse, StatusCode), Utxo, Any] =
     endpoint.get
-      .in("boxes" / "unspent" / path[String]("boxId"))
+      .in(rootPath / "boxes" / "unspent" / path[String]("boxId"))
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
       .out(jsonBody[Utxo])
@@ -43,7 +36,7 @@ trait BoxesByIdRoutes extends Codecs:
 
   protected[backend] val unspentBoxesByIds: PublicEndpoint[Set[String], (ErrorResponse, StatusCode), List[Utxo], Any] =
     endpoint.post
-      .in("boxes" / "unspent")
+      .in(rootPath / "boxes" / "unspent")
       .in(jsonBody[Set[String]])
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
@@ -58,7 +51,7 @@ trait BoxesByIdRoutes extends Codecs:
 
   protected[backend] val spentBoxById: PublicEndpoint[String, (ErrorResponse, StatusCode), Box, Any] =
     endpoint.get
-      .in("boxes" / "spent" / path[String]("boxId"))
+      .in(rootPath / "boxes" / "spent" / path[String]("boxId"))
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
       .out(jsonBody[Box])
@@ -79,7 +72,7 @@ trait BoxesByIdRoutes extends Codecs:
 
   protected[backend] val spentBoxesByIds: PublicEndpoint[Set[String], (ErrorResponse, StatusCode), List[Box], Any] =
     endpoint.post
-      .in("boxes" / "spent")
+      .in(rootPath / "boxes" / "spent")
       .in(jsonBody[Set[String]])
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
@@ -94,7 +87,7 @@ trait BoxesByIdRoutes extends Codecs:
 
   protected[backend] val anyBoxById: PublicEndpoint[String, (ErrorResponse, StatusCode), Box, Any] =
     endpoint.get
-      .in("boxes" / "any" / path[String]("boxId"))
+      .in(rootPath / "boxes" / "any" / path[String]("boxId"))
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
       .out(jsonBody[Box])
@@ -114,7 +107,7 @@ trait BoxesByIdRoutes extends Codecs:
 
   protected[backend] val anyBoxesByIds: PublicEndpoint[Set[String], (ErrorResponse, StatusCode), List[Box], Any] =
     endpoint.post
-      .in("boxes" / "any")
+      .in(rootPath / "boxes" / "any")
       .in(jsonBody[Set[String]])
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)

--- a/modules/backend/src/main/scala/org/ergoplatform/uexplorer/backend/boxes/BoxesByTokenIdRoutes.scala
+++ b/modules/backend/src/main/scala/org/ergoplatform/uexplorer/backend/boxes/BoxesByTokenIdRoutes.scala
@@ -1,6 +1,6 @@
 package org.ergoplatform.uexplorer.backend.boxes
 
-import org.ergoplatform.uexplorer.backend.{Codecs, ErrorResponse}
+import org.ergoplatform.uexplorer.backend.{Codecs, ErrorResponse, TapirRoutes}
 import org.ergoplatform.uexplorer.db.{Asset2Box, Box, Utxo}
 import org.ergoplatform.uexplorer.{BoxId, TxId}
 import sttp.model.{QueryParams, StatusCode}
@@ -11,11 +11,11 @@ import sttp.tapir.{queryParams, PublicEndpoint, Schema}
 import zio.*
 import zio.json.*
 
-trait BoxesByTokenIdRoutes extends Codecs:
+trait BoxesByTokenIdRoutes extends TapirRoutes with Codecs:
 
   protected[backend] val unspentAssetsByTokenId: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[Asset2Box], Any] =
     endpoint.get
-      .in("assets" / "unspent" / "by-token-id" / path[String]("tokenId"))
+      .in(rootPath / "assets" / "unspent" / "by-token-id" / path[String]("tokenId"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
@@ -30,7 +30,7 @@ trait BoxesByTokenIdRoutes extends Codecs:
 
   protected[backend] val spentAssetsByTokenId: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[Asset2Box], Any] =
     endpoint.get
-      .in("assets" / "spent" / "by-token-id" / path[String]("tokenId"))
+      .in(rootPath / "assets" / "spent" / "by-token-id" / path[String]("tokenId"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
@@ -45,7 +45,7 @@ trait BoxesByTokenIdRoutes extends Codecs:
 
   protected[backend] val anyAssetsByTokenId: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[Asset2Box], Any] =
     endpoint.get
-      .in("assets" / "any" / "by-token-id" / path[String]("tokenId"))
+      .in(rootPath / "assets" / "any" / "by-token-id" / path[String]("tokenId"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
@@ -60,7 +60,7 @@ trait BoxesByTokenIdRoutes extends Codecs:
 
   protected[backend] val unspentBoxesByTokenId: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[Utxo], Any] =
     endpoint.get
-      .in("boxes" / "unspent" / "by-token-id" / path[String]("tokenId"))
+      .in(rootPath / "boxes" / "unspent" / "by-token-id" / path[String]("tokenId"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
@@ -75,7 +75,7 @@ trait BoxesByTokenIdRoutes extends Codecs:
 
   protected[backend] val unspentBoxIdsByTokenId: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[BoxId], Any] =
     endpoint.get
-      .in("box-ids" / "unspent" / "by-token-id" / path[String]("tokenId"))
+      .in(rootPath / "box-ids" / "unspent" / "by-token-id" / path[String]("tokenId"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
@@ -91,7 +91,7 @@ trait BoxesByTokenIdRoutes extends Codecs:
 
   protected[backend] val spentBoxesByTokenId: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[Box], Any] =
     endpoint.get
-      .in("boxes" / "spent" / "by-token-id" / path[String]("tokenId"))
+      .in(rootPath / "boxes" / "spent" / "by-token-id" / path[String]("tokenId"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
@@ -106,7 +106,7 @@ trait BoxesByTokenIdRoutes extends Codecs:
 
   protected[backend] val spentBoxIdsByTokenId: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[BoxId], Any] =
     endpoint.get
-      .in("box-ids" / "spent" / "by-token-id" / path[String]("tokenId"))
+      .in(rootPath / "box-ids" / "spent" / "by-token-id" / path[String]("tokenId"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
@@ -122,7 +122,7 @@ trait BoxesByTokenIdRoutes extends Codecs:
 
   protected[backend] val anyBoxesByTokenId: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[Box], Any] =
     endpoint.get
-      .in("boxes" / "any" / "by-token-id" / path[String]("tokenId"))
+      .in(rootPath / "boxes" / "any" / "by-token-id" / path[String]("tokenId"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)
@@ -137,7 +137,7 @@ trait BoxesByTokenIdRoutes extends Codecs:
 
   protected[backend] val anyBoxIdsByTokenId: PublicEndpoint[(String, QueryParams), (ErrorResponse, StatusCode), Iterable[BoxId], Any] =
     endpoint.get
-      .in("box-ids" / "any" / "by-token-id" / path[String]("tokenId"))
+      .in(rootPath / "box-ids" / "any" / "by-token-id" / path[String]("tokenId"))
       .in(queryParams)
       .errorOut(jsonBody[ErrorResponse])
       .errorOut(statusCode)

--- a/modules/backend/src/test/scala/org/ergoplatform/uexplorer/backend/ProxyRoutesSpec.scala
+++ b/modules/backend/src/test/scala/org/ergoplatform/uexplorer/backend/ProxyRoutesSpec.scala
@@ -1,0 +1,29 @@
+package org.ergoplatform.uexplorer.backend
+
+import org.ergoplatform.uexplorer.CoreConf
+import org.ergoplatform.uexplorer.backend.blocks.{BlockService, PersistentBlockRepo}
+import org.ergoplatform.uexplorer.backend.boxes.{BoxRepo, BoxService, PersistentBoxRepo}
+import org.ergoplatform.uexplorer.http.{NodePool, NodePoolConf}
+import zio.*
+import zio.http.*
+import zio.json.*
+import zio.test.*
+
+trait ProxyRoutesSpec extends ZIOSpec[TestEnvironment] with ZioRoutes {
+
+  def proxyRoutesSpec(routes: App[Client with NodePool with BoxService with BlockService]) = suite("ProxyRoutesSpec")(test("proxy request") {
+    val path = Root / "peers" / "status"
+    val req  = Request.get(url = URL(path))
+
+    for {
+      body   <- routes.runZIO(req).flatMap(_.body.asString)
+      status <- ZIO.fromEither(body.fromJson[Status])
+    } yield assertTrue(true)
+  }).provide(routeLayers)
+}
+
+case class Status(lastIncomingMessage: Long, currentSystemTime: Long)
+object Status {
+  given JsonDecoder[Status] = DeriveJsonDecoder.gen[Status]
+  given JsonEncoder[Status] = DeriveJsonEncoder.gen[Status]
+}

--- a/modules/backend/src/test/scala/org/ergoplatform/uexplorer/backend/RouteSpec.scala
+++ b/modules/backend/src/test/scala/org/ergoplatform/uexplorer/backend/RouteSpec.scala
@@ -7,13 +7,17 @@ import org.ergoplatform.uexplorer.http.Rest
 import zio.ZIO
 import zio.test.{TestAspect, ZIOSpecDefault}
 
-object RouteSpec extends ZIOSpecDefault with BlockRoutesSpec with BoxRoutesSpec {
+object RouteSpec extends ZIOSpecDefault with BlockRoutesSpec with BoxRoutesSpec with ProxyRoutesSpec {
 
   implicit private val ps: CoreConf = CoreConf(NetworkPrefix.fromStringUnsafe("0"))
 
   def spec = suite("RouteSpec")(
-    blockRoutesSpec,
-    boxRoutesSpec
+    blockRoutesSpec(tapirWithProxyRoutes),
+    boxRoutesSpec(tapirWithProxyRoutes),
+    proxyRoutesSpec(tapirWithProxyRoutes),
+    blockRoutesSpec(zioHttpWithProxyRoutes),
+    boxRoutesSpec(zioHttpWithProxyRoutes),
+    proxyRoutesSpec(zioHttpWithProxyRoutes)
   ) @@ TestAspect.beforeAll(
     (for
       repo   <- ZIO.service[Repo]

--- a/modules/backend/src/test/scala/org/ergoplatform/uexplorer/backend/blocks/BlockRoutesSpec.scala
+++ b/modules/backend/src/test/scala/org/ergoplatform/uexplorer/backend/blocks/BlockRoutesSpec.scala
@@ -11,49 +11,44 @@ import eu.timepit.refined.auto.autoUnwrap
 import zio.json.interop.refined.*
 import org.ergoplatform.uexplorer.BlockId.unwrapped
 import org.ergoplatform.uexplorer.backend.blocks.Info
-import org.ergoplatform.uexplorer.backend.boxes.PersistentBoxRepo
+import org.ergoplatform.uexplorer.backend.boxes.{BoxService, PersistentBoxRepo}
 import org.ergoplatform.uexplorer.{CoreConf, NetworkPrefix}
-import org.ergoplatform.uexplorer.backend.{H2Backend, PersistentRepo, Repo}
+import org.ergoplatform.uexplorer.backend.{H2Backend, PersistentRepo, Repo, ZioRoutes}
 import org.ergoplatform.uexplorer.db.Block
-import org.ergoplatform.uexplorer.http.Rest
+import org.ergoplatform.uexplorer.http.{NodePool, Rest}
 
 import java.util.concurrent.TimeUnit
 
-trait BlockRoutesSpec extends ZIOSpec[TestEnvironment] {
+trait BlockRoutesSpec extends ZIOSpec[TestEnvironment] with ZioRoutes {
 
-  private val blockRoutes = BlockRoutes()
+  def blockRoutesSpec(routes: App[Client with NodePool with BoxService with BlockService]) =
+    suite("BlockRoutesSpec")(
+      test("get info") {
+        val path = Root / rootPath / "info"
+        val req  = Request.get(url = URL(path))
 
-  def blockRoutesSpec = suite("BlockRoutesSpec")(
-    test("get info") {
-      val path = Root / "info"
-      val req  = Request.get(url = URL(path))
+        for {
+          expectedBody <- routes.runZIO(req).flatMap(_.body.asString)
+          expectedInfo <- ZIO.fromEither(expectedBody.fromJson[Info])
+        } yield assertTrue(10 == expectedInfo.lastHeight)
+      },
+      test("get block by id") {
+        val path = Root / rootPath / "blocks" / Protocol.firstBlockId.unwrapped
+        val req  = Request.get(url = URL(path))
 
-      for {
-        expectedBody <- blockRoutes.runZIO(req).flatMap(_.body.asString)
-        expectedInfo <- ZIO.fromEither(expectedBody.fromJson[Info])
-      } yield assertTrue(10 == expectedInfo.lastHeight)
-    },
-    test("get block by id") {
-      val path = Root / "blocks" / Protocol.firstBlockId.unwrapped
-      val req  = Request.get(url = URL(path))
+        for {
+          expectedBody  <- routes.runZIO(req).flatMap(_.body.asString)
+          expectedBlock <- ZIO.fromEither(expectedBody.fromJson[Block])
+        } yield assertTrue(1 == expectedBlock.height)
+      },
+      test("get blocks by ids") {
+        val path = Root / rootPath / "blocks"
+        val req  = Request.post(url = URL(path), body = Body.fromString(List(Protocol.firstBlockId).toJson))
 
-      for {
-        expectedBody  <- blockRoutes.runZIO(req).flatMap(_.body.asString)
-        expectedBlock <- ZIO.fromEither(expectedBody.fromJson[Block])
-      } yield assertTrue(1 == expectedBlock.height)
-    },
-    test("get blocks by ids") {
-      val path = Root / "blocks"
-      val req  = Request.post(url = URL(path), body = Body.fromString(List(Protocol.firstBlockId).toJson))
-
-      for {
-        expectedBody   <- blockRoutes.runZIO(req).flatMap(_.body.asString)
-        expectedBlocks <- ZIO.fromEither(expectedBody.fromJson[List[Block]])
-      } yield assertTrue(List(1) == expectedBlocks.map(_.height))
-    }
-  ).provide(
-    H2Backend.zLayerFromConf,
-    BlockService.layer,
-    PersistentBlockRepo.layer
-  )
+        for {
+          expectedBody   <- routes.runZIO(req).flatMap(_.body.asString)
+          expectedBlocks <- ZIO.fromEither(expectedBody.fromJson[List[Block]])
+        } yield assertTrue(List(1) == expectedBlocks.map(_.height))
+      }
+    ).provide(routeLayers)
 }

--- a/modules/backend/src/test/scala/org/ergoplatform/uexplorer/backend/boxes/BoxRoutesSpec.scala
+++ b/modules/backend/src/test/scala/org/ergoplatform/uexplorer/backend/boxes/BoxRoutesSpec.scala
@@ -3,10 +3,10 @@ package org.ergoplatform.uexplorer.backend.boxes
 import eu.timepit.refined.auto.autoUnwrap
 import org.ergoplatform.uexplorer.Const.Protocol
 import org.ergoplatform.uexplorer.Const.Protocol.Emission
-import org.ergoplatform.uexplorer.backend.blocks.PersistentBlockRepo
-import org.ergoplatform.uexplorer.backend.{H2Backend, PersistentRepo, Repo}
+import org.ergoplatform.uexplorer.backend.blocks.{BlockService, PersistentBlockRepo}
+import org.ergoplatform.uexplorer.backend.{H2Backend, PersistentRepo, Repo, ZioRoutes}
 import org.ergoplatform.uexplorer.db.{Asset, Box, Utxo}
-import org.ergoplatform.uexplorer.http.Rest
+import org.ergoplatform.uexplorer.http.{NodePool, Rest}
 import org.ergoplatform.uexplorer.{BoxId, CoreConf, NetworkPrefix}
 import zio.*
 import zio.http.*
@@ -15,442 +15,431 @@ import zio.test.*
 
 import scala.collection.immutable.Set
 
-trait BoxRoutesSpec extends ZIOSpec[TestEnvironment] {
+trait BoxRoutesSpec extends ZIOSpec[TestEnvironment] with ZioRoutes {
 
-  private val boxRoutes                               = BoxRoutes()
   private val indexFilter: Map[String, Chunk[String]] = BoxService.indexWhiteList.map(key => key -> Chunk("")).toMap
 
-  def boxRoutesSpec = suite("BoxRoutesSpec")(
-    test("get spent/unspent/any box(es) by id") {
-      val unspentBoxGet        = Request.get(URL(Root / "boxes" / "unspent" / Protocol.firstBlockRewardBox.unwrapped))
-      val missingUnspentBoxGet = Request.get(URL(Root / "boxes" / "unspent" / Emission.outputBox.unwrapped))
-      val spentBoxGet          = Request.get(URL(Root / "boxes" / "spent" / Emission.outputBox.unwrapped))
-      val missingSpentBoxGet   = Request.get(URL(Root / "boxes" / "spent" / Protocol.firstBlockRewardBox.unwrapped))
-      val anyBoxGet            = Request.get(URL(Root / "boxes" / "any" / Emission.outputBox.unwrapped))
+  def boxRoutesSpec(routes: App[Client with NodePool with BoxService with BlockService]) =
+    suite("BoxRoutesSpec")(
+      test("get spent/unspent/any box(es) by id") {
+        val unspentBoxGet        = Request.get(URL(Root / rootPath / "boxes" / "unspent" / Protocol.firstBlockRewardBox.unwrapped))
+        val missingUnspentBoxGet = Request.get(URL(Root / rootPath / "boxes" / "unspent" / Emission.outputBox.unwrapped))
+        val spentBoxGet          = Request.get(URL(Root / rootPath / "boxes" / "spent" / Emission.outputBox.unwrapped))
+        val missingSpentBoxGet   = Request.get(URL(Root / rootPath / "boxes" / "spent" / Protocol.firstBlockRewardBox.unwrapped))
+        val anyBoxGet            = Request.get(URL(Root / rootPath / "boxes" / "any" / Emission.outputBox.unwrapped))
 
-      val unspentBoxPost =
-        Request.post(
-          Body.fromString(Set(Protocol.firstBlockRewardBox, Emission.outputBox).toJson),
-          URL(Root / "boxes" / "unspent")
+        val unspentBoxPost =
+          Request.post(
+            Body.fromString(Set(Protocol.firstBlockRewardBox, Emission.outputBox).toJson),
+            URL(Root / rootPath / "boxes" / "unspent")
+          )
+        val spentBoxPost =
+          Request.post(
+            Body.fromString(Set(Emission.outputBox, Protocol.firstBlockRewardBox).toJson),
+            URL(Root / rootPath / "boxes" / "spent")
+          )
+        val anyBoxPost =
+          Request.post(
+            Body.fromString(Set(Emission.outputBox, Protocol.firstBlockRewardBox).toJson),
+            URL(Root / rootPath / "boxes" / "any")
+          )
+
+        for {
+          unspentBox              <- routes.runZIO(unspentBoxGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[Utxo])))
+          unspentBoxes            <- routes.runZIO(unspentBoxPost).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[Set[Utxo]])))
+          spentBox                <- routes.runZIO(spentBoxGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[Box])))
+          anyBox                  <- routes.runZIO(anyBoxGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[Box])))
+          spentBoxes              <- routes.runZIO(spentBoxPost).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[Set[Box]])))
+          anyBoxes                <- routes.runZIO(anyBoxPost).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[Set[Box]])))
+          missingSpentBoxStatus   <- routes.runZIO(missingSpentBoxGet).map(_.status)
+          missingUnspentBoxStatus <- routes.runZIO(missingUnspentBoxGet).map(_.status)
+        } yield assertTrue(
+          unspentBox.boxId == Protocol.firstBlockRewardBox,
+          unspentBoxes.map(_.boxId) == Set(Protocol.firstBlockRewardBox),
+          spentBox.boxId == Emission.outputBox,
+          anyBox.boxId == Emission.outputBox,
+          spentBoxes.map(_.boxId) == Set(Emission.outputBox),
+          anyBoxes.map(_.boxId) == Set(Emission.outputBox, Protocol.firstBlockRewardBox),
+          missingSpentBoxStatus == Status.NotFound,
+          missingUnspentBoxStatus == Status.NotFound
         )
-      val spentBoxPost =
-        Request.post(
-          Body.fromString(Set(Emission.outputBox, Protocol.firstBlockRewardBox).toJson),
-          URL(Root / "boxes" / "spent")
+      },
+      test("get spent/unspent/any box(es) by address") {
+        val spentBoxesByAddressGet   = Request.get(URL(Root / rootPath / "boxes" / "spent" / "by-address" / Emission.address))
+        val unspentBoxesByAddressGet = Request.get(URL(Root / rootPath / "boxes" / "unspent" / "by-address" / Emission.address))
+        val anyBoxesByAddressGet     = Request.get(URL(Root / rootPath / "boxes" / "any" / "by-address" / Emission.address))
+
+        val spentBoxIdsByAddressGet   = Request.get(URL(Root / rootPath / "box-ids" / "spent" / "by-address" / Emission.address))
+        val unspentBoxIdsByAddressGet = Request.get(URL(Root / rootPath / "box-ids" / "unspent" / "by-address" / Emission.address))
+        val anyBoxIdsByAddressGet     = Request.get(URL(Root / rootPath / "box-ids" / "any" / "by-address" / Emission.address))
+
+        for {
+          spentBoxesByAddress <-
+            routes.runZIO(spentBoxesByAddressGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
+          unspentBoxesByAddress <-
+            routes.runZIO(unspentBoxesByAddressGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Utxo]])))
+          anyBoxesByAddress <- routes.runZIO(anyBoxesByAddressGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
+          spentBoxIdsByAddress <-
+            routes.runZIO(spentBoxIdsByAddressGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
+          unspentBoxIdsByAddress <-
+            routes.runZIO(unspentBoxIdsByAddressGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
+          anyBoxIdsByAddress <-
+            routes.runZIO(anyBoxIdsByAddressGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
+        } yield assertTrue(
+          unspentBoxesByAddress.map(_.boxId).intersect(spentBoxesByAddress.map(_.boxId)).isEmpty,
+          unspentBoxesByAddress.map(_.boxId).nonEmpty,
+          spentBoxesByAddress.map(_.boxId).nonEmpty,
+          spentBoxesByAddress.size + unspentBoxesByAddress.size == anyBoxesByAddress.size,
+          unspentBoxIdsByAddress.intersect(spentBoxIdsByAddress).isEmpty,
+          unspentBoxIdsByAddress.nonEmpty,
+          spentBoxIdsByAddress.nonEmpty,
+          spentBoxIdsByAddress.size + unspentBoxIdsByAddress.size == anyBoxIdsByAddress.size
         )
-      val anyBoxPost =
-        Request.post(
-          Body.fromString(Set(Emission.outputBox, Protocol.firstBlockRewardBox).toJson),
-          URL(Root / "boxes" / "any")
+      },
+      test("get spent/unspent/any box contracts by ergo-tree") {
+        val spentBoxesByErgoTreeGet   = Request.get(URL(Root / rootPath / "boxes" / "spent" / "contracts" / "by-ergo-tree" / Emission.ergoTreeHex))
+        val unspentBoxesByErgoTreeGet = Request.get(URL(Root / rootPath / "boxes" / "unspent" / "contracts" / "by-ergo-tree" / Emission.ergoTreeHex))
+        val anyBoxesByErgoTreeGet     = Request.get(URL(Root / rootPath / "boxes" / "any" / "contracts" / "by-ergo-tree" / Emission.ergoTreeHex))
+
+        val spentBoxIdsByErgoTreeGet   = Request.get(URL(Root / rootPath / "box-ids" / "spent" / "contracts" / "by-ergo-tree" / Emission.ergoTreeHex))
+        val unspentBoxIdsByErgoTreeGet = Request.get(URL(Root / rootPath / "box-ids" / "unspent" / "contracts" / "by-ergo-tree" / Emission.ergoTreeHex))
+        val anyBoxIdsByErgoTreeGet     = Request.get(URL(Root / rootPath / "box-ids" / "any" / "contracts" / "by-ergo-tree" / Emission.ergoTreeHex))
+
+        for {
+          spentBoxesByErgoTree <-
+            routes.runZIO(spentBoxesByErgoTreeGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
+          unspentBoxesByErgoTree <-
+            routes.runZIO(unspentBoxesByErgoTreeGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Utxo]])))
+          anyBoxesByErgoTree <- routes.runZIO(anyBoxesByErgoTreeGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
+          spentBoxIdsByErgoTree <-
+            routes.runZIO(spentBoxIdsByErgoTreeGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
+          unspentBoxIdsByErgoTree <-
+            routes.runZIO(unspentBoxIdsByErgoTreeGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
+          anyBoxIdsByErgoTree <-
+            routes.runZIO(anyBoxIdsByErgoTreeGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
+        } yield assertTrue(
+          unspentBoxesByErgoTree.map(_.boxId).intersect(spentBoxesByErgoTree.map(_.boxId)).isEmpty,
+          unspentBoxesByErgoTree.map(_.boxId).nonEmpty,
+          spentBoxesByErgoTree.map(_.boxId).nonEmpty,
+          spentBoxesByErgoTree.size + unspentBoxesByErgoTree.size == anyBoxesByErgoTree.size,
+          unspentBoxIdsByErgoTree.intersect(spentBoxIdsByErgoTree).isEmpty,
+          unspentBoxIdsByErgoTree.nonEmpty,
+          spentBoxIdsByErgoTree.nonEmpty,
+          spentBoxIdsByErgoTree.size + unspentBoxIdsByErgoTree.size == anyBoxIdsByErgoTree.size
         )
+      },
+      test("get spent/unspent/any box templates by ergo-tree") {
+        val spentBoxesByErgoTreeT8Get   = Request.get(URL(Root / rootPath / "boxes" / "spent" / "templates" / "by-ergo-tree" / Emission.ergoTreeHex))
+        val unspentBoxesByErgoTreeT8Get = Request.get(URL(Root / rootPath / "boxes" / "unspent" / "templates" / "by-ergo-tree" / Emission.ergoTreeHex))
+        val anyBoxesByErgoTreeT8Get     = Request.get(URL(Root / rootPath / "boxes" / "any" / "templates" / "by-ergo-tree" / Emission.ergoTreeHex))
 
-      for {
-        unspentBox              <- boxRoutes.runZIO(unspentBoxGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[Utxo])))
-        unspentBoxes            <- boxRoutes.runZIO(unspentBoxPost).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[Set[Utxo]])))
-        spentBox                <- boxRoutes.runZIO(spentBoxGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[Box])))
-        anyBox                  <- boxRoutes.runZIO(anyBoxGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[Box])))
-        spentBoxes              <- boxRoutes.runZIO(spentBoxPost).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[Set[Box]])))
-        anyBoxes                <- boxRoutes.runZIO(anyBoxPost).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[Set[Box]])))
-        missingSpentBoxStatus   <- boxRoutes.runZIO(missingSpentBoxGet).map(_.status)
-        missingUnspentBoxStatus <- boxRoutes.runZIO(missingUnspentBoxGet).map(_.status)
-      } yield assertTrue(
-        unspentBox.boxId == Protocol.firstBlockRewardBox,
-        unspentBoxes.map(_.boxId) == Set(Protocol.firstBlockRewardBox),
-        spentBox.boxId == Emission.outputBox,
-        anyBox.boxId == Emission.outputBox,
-        spentBoxes.map(_.boxId) == Set(Emission.outputBox),
-        anyBoxes.map(_.boxId) == Set(Emission.outputBox, Protocol.firstBlockRewardBox),
-        missingSpentBoxStatus == Status.NotFound,
-        missingUnspentBoxStatus == Status.NotFound
-      )
-    }.provide(
-      H2Backend.zLayerFromConf,
-      PersistentBoxRepo.layer,
-      BoxService.layer,
-      CoreConf.layer
-    ),
-    test("get spent/unspent/any box(es) by address") {
-      val spentBoxesByAddressGet   = Request.get(URL(Root / "boxes" / "spent" / "by-address" / Emission.address))
-      val unspentBoxesByAddressGet = Request.get(URL(Root / "boxes" / "unspent" / "by-address" / Emission.address))
-      val anyBoxesByAddressGet     = Request.get(URL(Root / "boxes" / "any" / "by-address" / Emission.address))
+        val spentBoxIdsByErgoTreeT8Get   = Request.get(URL(Root / rootPath / "box-ids" / "spent" / "templates" / "by-ergo-tree" / Emission.ergoTreeHex))
+        val unspentBoxIdsByErgoTreeT8Get = Request.get(URL(Root / rootPath / "box-ids" / "unspent" / "templates" / "by-ergo-tree" / Emission.ergoTreeHex))
+        val anyBoxIdsByErgoTreeT8Get     = Request.get(URL(Root / rootPath / "box-ids" / "any" / "templates" / "by-ergo-tree" / Emission.ergoTreeHex))
+        for {
+          spentBoxesByErgoTreeT8 <-
+            routes.runZIO(spentBoxesByErgoTreeT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
+          unspentBoxesByErgoTreeT8 <-
+            routes.runZIO(unspentBoxesByErgoTreeT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Utxo]])))
+          anyBoxesByErgoTreeT8 <-
+            routes.runZIO(anyBoxesByErgoTreeT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
+          spentBoxIdsByErgoTreeT8 <-
+            routes.runZIO(spentBoxIdsByErgoTreeT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
+          unspentBoxIdsByErgoTreeT8 <-
+            routes.runZIO(unspentBoxIdsByErgoTreeT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
+          anyBoxIdsByErgoTreeT8 <-
+            routes.runZIO(anyBoxIdsByErgoTreeT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
+        } yield assertTrue(
+          // hard to get any real template when we have just first 4000 blocks that have no templates
+          unspentBoxesByErgoTreeT8.map(_.boxId).intersect(spentBoxesByErgoTreeT8.map(_.boxId)).isEmpty,
+          unspentBoxesByErgoTreeT8.map(_.boxId).isEmpty,
+          spentBoxesByErgoTreeT8.map(_.boxId).isEmpty,
+          spentBoxesByErgoTreeT8.size + unspentBoxesByErgoTreeT8.size == anyBoxesByErgoTreeT8.size,
+          unspentBoxIdsByErgoTreeT8.intersect(spentBoxIdsByErgoTreeT8).isEmpty,
+          unspentBoxIdsByErgoTreeT8.isEmpty,
+          spentBoxIdsByErgoTreeT8.isEmpty,
+          spentBoxIdsByErgoTreeT8.size + unspentBoxIdsByErgoTreeT8.size == anyBoxIdsByErgoTreeT8.size
+        )
+      },
+      test("get spent/unspent/any box contracts by ergo-tree-hash") {
+        val spentBoxesByErgoTreeHashGet   = Request.get(URL(Root / rootPath / "boxes" / "spent" / "contracts" / "by-ergo-tree-hash" / Emission.ergoTreeHash))
+        val unspentBoxesByErgoTreeHashGet = Request.get(URL(Root / rootPath / "boxes" / "unspent" / "contracts" / "by-ergo-tree-hash" / Emission.ergoTreeHash))
+        val anyBoxesByErgoTreeHashGet     = Request.get(URL(Root / rootPath / "boxes" / "any" / "contracts" / "by-ergo-tree-hash" / Emission.ergoTreeHash))
 
-      val spentBoxIdsByAddressGet   = Request.get(URL(Root / "box-ids" / "spent" / "by-address" / Emission.address))
-      val unspentBoxIdsByAddressGet = Request.get(URL(Root / "box-ids" / "unspent" / "by-address" / Emission.address))
-      val anyBoxIdsByAddressGet     = Request.get(URL(Root / "box-ids" / "any" / "by-address" / Emission.address))
+        val spentBoxIdsByErgoTreeHashGet = Request.get(URL(Root / rootPath / "box-ids" / "spent" / "contracts" / "by-ergo-tree-hash" / Emission.ergoTreeHash))
+        val unspentBoxIdsByErgoTreeHashGet =
+          Request.get(URL(Root / rootPath / "box-ids" / "unspent" / "contracts" / "by-ergo-tree-hash" / Emission.ergoTreeHash))
+        val anyBoxIdsByErgoTreeHashGet = Request.get(URL(Root / rootPath / "box-ids" / "any" / "contracts" / "by-ergo-tree-hash" / Emission.ergoTreeHash))
 
-      for {
-        spentBoxesByAddress    <- boxRoutes.runZIO(spentBoxesByAddressGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
-        unspentBoxesByAddress  <- boxRoutes.runZIO(unspentBoxesByAddressGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Utxo]])))
-        anyBoxesByAddress      <- boxRoutes.runZIO(anyBoxesByAddressGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
-        spentBoxIdsByAddress   <- boxRoutes.runZIO(spentBoxIdsByAddressGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
-        unspentBoxIdsByAddress <- boxRoutes.runZIO(unspentBoxIdsByAddressGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
-        anyBoxIdsByAddress     <- boxRoutes.runZIO(anyBoxIdsByAddressGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
-      } yield assertTrue(
-        unspentBoxesByAddress.map(_.boxId).intersect(spentBoxesByAddress.map(_.boxId)).isEmpty,
-        unspentBoxesByAddress.map(_.boxId).nonEmpty,
-        spentBoxesByAddress.map(_.boxId).nonEmpty,
-        spentBoxesByAddress.size + unspentBoxesByAddress.size == anyBoxesByAddress.size,
-        unspentBoxIdsByAddress.intersect(spentBoxIdsByAddress).isEmpty,
-        unspentBoxIdsByAddress.nonEmpty,
-        spentBoxIdsByAddress.nonEmpty,
-        spentBoxIdsByAddress.size + unspentBoxIdsByAddress.size == anyBoxIdsByAddress.size
-      )
-    }.provide(
-      H2Backend.zLayerFromConf,
-      PersistentBoxRepo.layer,
-      BoxService.layer,
-      CoreConf.layer
-    ),
-    test("get spent/unspent/any box contracts by ergo-tree") {
-      val spentBoxesByErgoTreeGet   = Request.get(URL(Root / "boxes" / "spent" / "contracts" / "by-ergo-tree" / Emission.ergoTreeHex))
-      val unspentBoxesByErgoTreeGet = Request.get(URL(Root / "boxes" / "unspent" / "contracts" / "by-ergo-tree" / Emission.ergoTreeHex))
-      val anyBoxesByErgoTreeGet     = Request.get(URL(Root / "boxes" / "any" / "contracts" / "by-ergo-tree" / Emission.ergoTreeHex))
+        for {
+          spentBoxesByErgoTreeHash <-
+            routes.runZIO(spentBoxesByErgoTreeHashGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
+          unspentBoxesByErgoTreeHash <-
+            routes.runZIO(unspentBoxesByErgoTreeHashGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Utxo]])))
+          anyBoxesByErgoTreeHash <-
+            routes.runZIO(anyBoxesByErgoTreeHashGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
+          spentBoxIdsByErgoTreeHash <-
+            routes.runZIO(spentBoxIdsByErgoTreeHashGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
+          unspentBoxIdsByErgoTreeHash <-
+            routes.runZIO(unspentBoxIdsByErgoTreeHashGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
+          anyBoxIdsByErgoTreeHash <-
+            routes.runZIO(anyBoxIdsByErgoTreeHashGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
+        } yield assertTrue(
+          unspentBoxesByErgoTreeHash.map(_.boxId).intersect(spentBoxesByErgoTreeHash.map(_.boxId)).isEmpty,
+          unspentBoxesByErgoTreeHash.map(_.boxId).nonEmpty,
+          spentBoxesByErgoTreeHash.map(_.boxId).nonEmpty,
+          spentBoxesByErgoTreeHash.size + unspentBoxesByErgoTreeHash.size == anyBoxesByErgoTreeHash.size,
+          unspentBoxIdsByErgoTreeHash.intersect(spentBoxIdsByErgoTreeHash).isEmpty,
+          unspentBoxIdsByErgoTreeHash.nonEmpty,
+          spentBoxIdsByErgoTreeHash.nonEmpty,
+          spentBoxIdsByErgoTreeHash.size + unspentBoxIdsByErgoTreeHash.size == anyBoxesByErgoTreeHash.size
+        )
+      },
+      test("get spent/unspent/any box templates by ergo-tree-hash") {
+        val spentByErgoTreeHashT8Get   = Request.get(URL(Root / rootPath / "boxes" / "spent" / "templates" / "by-ergo-tree-hash" / Emission.ergoTreeHash))
+        val unspentByErgoTreeHashT8Get = Request.get(URL(Root / rootPath / "boxes" / "unspent" / "templates" / "by-ergo-tree-hash" / Emission.ergoTreeHash))
+        val anyByErgoTreeHashT8Get     = Request.get(URL(Root / rootPath / "boxes" / "any" / "templates" / "by-ergo-tree-hash" / Emission.ergoTreeHash))
 
-      val spentBoxIdsByErgoTreeGet   = Request.get(URL(Root / "box-ids" / "spent" / "contracts" / "by-ergo-tree" / Emission.ergoTreeHex))
-      val unspentBoxIdsByErgoTreeGet = Request.get(URL(Root / "box-ids" / "unspent" / "contracts" / "by-ergo-tree" / Emission.ergoTreeHex))
-      val anyBoxIdsByErgoTreeGet     = Request.get(URL(Root / "box-ids" / "any" / "contracts" / "by-ergo-tree" / Emission.ergoTreeHex))
+        val spentIdsByErgoTreeHashT8Get = Request.get(URL(Root / rootPath / "box-ids" / "spent" / "templates" / "by-ergo-tree-hash" / Emission.ergoTreeHash))
+        val unspentIdsByErgoTreeHashT8Get =
+          Request.get(URL(Root / rootPath / "box-ids" / "unspent" / "templates" / "by-ergo-tree-hash" / Emission.ergoTreeHash))
+        val anyIdsByErgoTreeHashT8Get = Request.get(URL(Root / rootPath / "box-ids" / "any" / "templates" / "by-ergo-tree-hash" / Emission.ergoTreeHash))
 
-      for {
-        spentBoxesByErgoTree    <- boxRoutes.runZIO(spentBoxesByErgoTreeGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
-        unspentBoxesByErgoTree  <- boxRoutes.runZIO(unspentBoxesByErgoTreeGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Utxo]])))
-        anyBoxesByErgoTree      <- boxRoutes.runZIO(anyBoxesByErgoTreeGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
-        spentBoxIdsByErgoTree   <- boxRoutes.runZIO(spentBoxIdsByErgoTreeGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
-        unspentBoxIdsByErgoTree <- boxRoutes.runZIO(unspentBoxIdsByErgoTreeGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
-        anyBoxIdsByErgoTree     <- boxRoutes.runZIO(anyBoxIdsByErgoTreeGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
-      } yield assertTrue(
-        unspentBoxesByErgoTree.map(_.boxId).intersect(spentBoxesByErgoTree.map(_.boxId)).isEmpty,
-        unspentBoxesByErgoTree.map(_.boxId).nonEmpty,
-        spentBoxesByErgoTree.map(_.boxId).nonEmpty,
-        spentBoxesByErgoTree.size + unspentBoxesByErgoTree.size == anyBoxesByErgoTree.size,
-        unspentBoxIdsByErgoTree.intersect(spentBoxIdsByErgoTree).isEmpty,
-        unspentBoxIdsByErgoTree.nonEmpty,
-        spentBoxIdsByErgoTree.nonEmpty,
-        spentBoxIdsByErgoTree.size + unspentBoxIdsByErgoTree.size == anyBoxIdsByErgoTree.size
-      )
-    }.provide(
-      H2Backend.zLayerFromConf,
-      PersistentBoxRepo.layer,
-      BoxService.layer,
-      CoreConf.layer
-    ),
-    test("get spent/unspent/any box templates by ergo-tree") {
-      val spentBoxesByErgoTreeT8Get   = Request.get(URL(Root / "boxes" / "spent" / "templates" / "by-ergo-tree" / Emission.ergoTreeHex))
-      val unspentBoxesByErgoTreeT8Get = Request.get(URL(Root / "boxes" / "unspent" / "templates" / "by-ergo-tree" / Emission.ergoTreeHex))
-      val anyBoxesByErgoTreeT8Get     = Request.get(URL(Root / "boxes" / "any" / "templates" / "by-ergo-tree" / Emission.ergoTreeHex))
+        for {
+          spentByErgoTreeT8Hash <-
+            routes.runZIO(spentByErgoTreeHashT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
+          unspentByErgoTreeT8Hash <-
+            routes.runZIO(unspentByErgoTreeHashT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Utxo]])))
+          anyByErgoTreeT8Hash <-
+            routes.runZIO(anyByErgoTreeHashT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
+          spentIdsByErgoTreeT8Hash <-
+            routes.runZIO(spentIdsByErgoTreeHashT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
+          unspentIdsByErgoTreeT8Hash <-
+            routes.runZIO(unspentIdsByErgoTreeHashT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
+          anyIdsByErgoTreeT8Hash <-
+            routes.runZIO(anyIdsByErgoTreeHashT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
+        } yield assertTrue(
+          unspentByErgoTreeT8Hash.map(_.boxId).intersect(spentByErgoTreeT8Hash.map(_.boxId)).isEmpty,
+          unspentByErgoTreeT8Hash.map(_.boxId).isEmpty,
+          spentByErgoTreeT8Hash.map(_.boxId).isEmpty,
+          spentByErgoTreeT8Hash.size + unspentByErgoTreeT8Hash.size == anyByErgoTreeT8Hash.size,
+          unspentIdsByErgoTreeT8Hash.intersect(spentIdsByErgoTreeT8Hash).isEmpty,
+          unspentIdsByErgoTreeT8Hash.isEmpty,
+          spentIdsByErgoTreeT8Hash.isEmpty,
+          spentIdsByErgoTreeT8Hash.size + unspentIdsByErgoTreeT8Hash.size == anyIdsByErgoTreeT8Hash.size
+        )
+      },
+      test("get spent/unspent/any box(es) by address with index filter") {
+        val spentByAddressGet   = Request.get(URL(Root / rootPath / "boxes" / "spent" / "by-address" / Emission.address).withQueryParams(indexFilter))
+        val unspentByAddressGet = Request.get(URL(Root / rootPath / "boxes" / "unspent" / "by-address" / Emission.address).withQueryParams(indexFilter))
+        val anyByAddressGet     = Request.get(URL(Root / rootPath / "boxes" / "any" / "by-address" / Emission.address).withQueryParams(indexFilter))
 
-      val spentBoxIdsByErgoTreeT8Get   = Request.get(URL(Root / "box-ids" / "spent" / "templates" / "by-ergo-tree" / Emission.ergoTreeHex))
-      val unspentBoxIdsByErgoTreeT8Get = Request.get(URL(Root / "box-ids" / "unspent" / "templates" / "by-ergo-tree" / Emission.ergoTreeHex))
-      val anyBoxIdsByErgoTreeT8Get     = Request.get(URL(Root / "box-ids" / "any" / "templates" / "by-ergo-tree" / Emission.ergoTreeHex))
-      for {
-        spentBoxesByErgoTreeT8   <- boxRoutes.runZIO(spentBoxesByErgoTreeT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
-        unspentBoxesByErgoTreeT8 <- boxRoutes.runZIO(unspentBoxesByErgoTreeT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Utxo]])))
-        anyBoxesByErgoTreeT8     <- boxRoutes.runZIO(anyBoxesByErgoTreeT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
-        spentBoxIdsByErgoTreeT8  <- boxRoutes.runZIO(spentBoxIdsByErgoTreeT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
-        unspentBoxIdsByErgoTreeT8 <-
-          boxRoutes.runZIO(unspentBoxIdsByErgoTreeT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
-        anyBoxIdsByErgoTreeT8 <- boxRoutes.runZIO(anyBoxIdsByErgoTreeT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
-      } yield assertTrue(
-        // hard to get any real template when we have just first 4000 blocks that have no templates
-        unspentBoxesByErgoTreeT8.map(_.boxId).intersect(spentBoxesByErgoTreeT8.map(_.boxId)).isEmpty,
-        unspentBoxesByErgoTreeT8.map(_.boxId).isEmpty,
-        spentBoxesByErgoTreeT8.map(_.boxId).isEmpty,
-        spentBoxesByErgoTreeT8.size + unspentBoxesByErgoTreeT8.size == anyBoxesByErgoTreeT8.size,
-        unspentBoxIdsByErgoTreeT8.intersect(spentBoxIdsByErgoTreeT8).isEmpty,
-        unspentBoxIdsByErgoTreeT8.isEmpty,
-        spentBoxIdsByErgoTreeT8.isEmpty,
-        spentBoxIdsByErgoTreeT8.size + unspentBoxIdsByErgoTreeT8.size == anyBoxIdsByErgoTreeT8.size
-      )
-    }.provide(
-      H2Backend.zLayerFromConf,
-      PersistentBoxRepo.layer,
-      BoxService.layer,
-      CoreConf.layer
-    ),
-    test("get spent/unspent/any box contracts by ergo-tree-hash") {
-      val spentBoxesByErgoTreeHashGet   = Request.get(URL(Root / "boxes" / "spent" / "contracts" / "by-ergo-tree-hash" / Emission.ergoTreeHash))
-      val unspentBoxesByErgoTreeHashGet = Request.get(URL(Root / "boxes" / "unspent" / "contracts" / "by-ergo-tree-hash" / Emission.ergoTreeHash))
-      val anyBoxesByErgoTreeHashGet     = Request.get(URL(Root / "boxes" / "any" / "contracts" / "by-ergo-tree-hash" / Emission.ergoTreeHash))
+        val spentIdsByAddressGet   = Request.get(URL(Root / rootPath / "box-ids" / "spent" / "by-address" / Emission.address).withQueryParams(indexFilter))
+        val unspentIdsByAddressGet = Request.get(URL(Root / rootPath / "box-ids" / "unspent" / "by-address" / Emission.address).withQueryParams(indexFilter))
+        val anyIdsByAddressGet     = Request.get(URL(Root / rootPath / "box-ids" / "any" / "by-address" / Emission.address).withQueryParams(indexFilter))
 
-      val spentBoxIdsByErgoTreeHashGet   = Request.get(URL(Root / "box-ids" / "spent" / "contracts" / "by-ergo-tree-hash" / Emission.ergoTreeHash))
-      val unspentBoxIdsByErgoTreeHashGet = Request.get(URL(Root / "box-ids" / "unspent" / "contracts" / "by-ergo-tree-hash" / Emission.ergoTreeHash))
-      val anyBoxIdsByErgoTreeHashGet     = Request.get(URL(Root / "box-ids" / "any" / "contracts" / "by-ergo-tree-hash" / Emission.ergoTreeHash))
+        for {
+          spentByAddress    <- routes.runZIO(spentByAddressGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
+          unspentByAddress  <- routes.runZIO(unspentByAddressGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Utxo]])))
+          anyByAddress      <- routes.runZIO(anyByAddressGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
+          spentIdsByAddress <- routes.runZIO(spentIdsByAddressGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
+          unspentIdsByAddress <-
+            routes.runZIO(unspentIdsByAddressGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
+          anyIdsByAddress <- routes.runZIO(anyIdsByAddressGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
+        } yield assertTrue(
+          unspentByAddress.map(_.boxId).intersect(spentByAddress.map(_.boxId)).isEmpty,
+          unspentByAddress.map(_.boxId).isEmpty,
+          spentByAddress.map(_.boxId).isEmpty,
+          spentByAddress.size + unspentByAddress.size == anyByAddress.size,
+          unspentIdsByAddress.intersect(spentIdsByAddress).isEmpty,
+          unspentIdsByAddress.isEmpty,
+          spentIdsByAddress.isEmpty,
+          spentIdsByAddress.size + unspentIdsByAddress.size == anyIdsByAddress.size
+        )
+      },
+      test("get spent/unspent/any box contracts by ergo-tree with index filter") {
+        val spentByErgoTreeGet =
+          Request.get(URL(Root / rootPath / "boxes" / "spent" / "contracts" / "by-ergo-tree" / Emission.ergoTreeHex).withQueryParams(indexFilter))
+        val unspentByErgoTreeGet =
+          Request.get(URL(Root / rootPath / "boxes" / "unspent" / "contracts" / "by-ergo-tree" / Emission.ergoTreeHex).withQueryParams(indexFilter))
+        val anyByErgoTreeGet =
+          Request.get(URL(Root / rootPath / "boxes" / "any" / "contracts" / "by-ergo-tree" / Emission.ergoTreeHex).withQueryParams(indexFilter))
 
-      for {
-        spentBoxesByErgoTreeHash <- boxRoutes.runZIO(spentBoxesByErgoTreeHashGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
-        unspentBoxesByErgoTreeHash <-
-          boxRoutes.runZIO(unspentBoxesByErgoTreeHashGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Utxo]])))
-        anyBoxesByErgoTreeHash <- boxRoutes.runZIO(anyBoxesByErgoTreeHashGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
-        spentBoxIdsByErgoTreeHash <-
-          boxRoutes.runZIO(spentBoxIdsByErgoTreeHashGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
-        unspentBoxIdsByErgoTreeHash <-
-          boxRoutes.runZIO(unspentBoxIdsByErgoTreeHashGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
-        anyBoxIdsByErgoTreeHash <- boxRoutes.runZIO(anyBoxIdsByErgoTreeHashGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
-      } yield assertTrue(
-        unspentBoxesByErgoTreeHash.map(_.boxId).intersect(spentBoxesByErgoTreeHash.map(_.boxId)).isEmpty,
-        unspentBoxesByErgoTreeHash.map(_.boxId).nonEmpty,
-        spentBoxesByErgoTreeHash.map(_.boxId).nonEmpty,
-        spentBoxesByErgoTreeHash.size + unspentBoxesByErgoTreeHash.size == anyBoxesByErgoTreeHash.size,
-        unspentBoxIdsByErgoTreeHash.intersect(spentBoxIdsByErgoTreeHash).isEmpty,
-        unspentBoxIdsByErgoTreeHash.nonEmpty,
-        spentBoxIdsByErgoTreeHash.nonEmpty,
-        spentBoxIdsByErgoTreeHash.size + unspentBoxIdsByErgoTreeHash.size == anyBoxesByErgoTreeHash.size
-      )
-    }.provide(
-      H2Backend.zLayerFromConf,
-      PersistentBoxRepo.layer,
-      BoxService.layer,
-      CoreConf.layer
-    ),
-    test("get spent/unspent/any box templates by ergo-tree-hash") {
-      val spentByErgoTreeHashT8Get   = Request.get(URL(Root / "boxes" / "spent" / "templates" / "by-ergo-tree-hash" / Emission.ergoTreeHash))
-      val unspentByErgoTreeHashT8Get = Request.get(URL(Root / "boxes" / "unspent" / "templates" / "by-ergo-tree-hash" / Emission.ergoTreeHash))
-      val anyByErgoTreeHashT8Get     = Request.get(URL(Root / "boxes" / "any" / "templates" / "by-ergo-tree-hash" / Emission.ergoTreeHash))
+        val spentIdsByErgoTreeGet =
+          Request.get(URL(Root / rootPath / "box-ids" / "spent" / "contracts" / "by-ergo-tree" / Emission.ergoTreeHex).withQueryParams(indexFilter))
+        val unspentIdsByErgoTreeGet =
+          Request.get(URL(Root / rootPath / "box-ids" / "unspent" / "contracts" / "by-ergo-tree" / Emission.ergoTreeHex).withQueryParams(indexFilter))
+        val anyIdsByErgoTreeGet =
+          Request.get(URL(Root / rootPath / "boxes" / "any" / "contracts" / "by-ergo-tree" / Emission.ergoTreeHex).withQueryParams(indexFilter))
 
-      val spentIdsByErgoTreeHashT8Get   = Request.get(URL(Root / "box-ids" / "spent" / "templates" / "by-ergo-tree-hash" / Emission.ergoTreeHash))
-      val unspentIdsByErgoTreeHashT8Get = Request.get(URL(Root / "box-ids" / "unspent" / "templates" / "by-ergo-tree-hash" / Emission.ergoTreeHash))
-      val anyIdsByErgoTreeHashT8Get     = Request.get(URL(Root / "box-ids" / "any" / "templates" / "by-ergo-tree-hash" / Emission.ergoTreeHash))
+        for {
+          spentByErgoTree   <- routes.runZIO(spentByErgoTreeGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
+          unspentByErgoTree <- routes.runZIO(unspentByErgoTreeGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Utxo]])))
+          anyByErgoTree     <- routes.runZIO(anyByErgoTreeGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
+          spentIdsByErgoTree <-
+            routes.runZIO(spentIdsByErgoTreeGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
+          unspentIdsByErgoTree <-
+            routes.runZIO(unspentIdsByErgoTreeGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
+          anyIdsByErgoTree <- routes.runZIO(anyIdsByErgoTreeGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
+        } yield assertTrue(
+          unspentByErgoTree.map(_.boxId).intersect(spentByErgoTree.map(_.boxId)).isEmpty,
+          unspentByErgoTree.map(_.boxId).isEmpty,
+          spentByErgoTree.map(_.boxId).isEmpty,
+          spentByErgoTree.size + unspentByErgoTree.size == anyByErgoTree.size,
+          unspentIdsByErgoTree.intersect(spentIdsByErgoTree).isEmpty,
+          unspentIdsByErgoTree.isEmpty,
+          spentIdsByErgoTree.isEmpty,
+          spentIdsByErgoTree.size + unspentIdsByErgoTree.size == anyIdsByErgoTree.size
+        )
+      },
+      test("get spent/unspent/any box templates by ergo-tree with index filter") {
 
-      for {
-        spentByErgoTreeT8Hash    <- boxRoutes.runZIO(spentByErgoTreeHashT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
-        unspentByErgoTreeT8Hash  <- boxRoutes.runZIO(unspentByErgoTreeHashT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Utxo]])))
-        anyByErgoTreeT8Hash      <- boxRoutes.runZIO(anyByErgoTreeHashT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
-        spentIdsByErgoTreeT8Hash <- boxRoutes.runZIO(spentIdsByErgoTreeHashT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
-        unspentIdsByErgoTreeT8Hash <-
-          boxRoutes.runZIO(unspentIdsByErgoTreeHashT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
-        anyIdsByErgoTreeT8Hash <- boxRoutes.runZIO(anyIdsByErgoTreeHashT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
-      } yield assertTrue(
-        unspentByErgoTreeT8Hash.map(_.boxId).intersect(spentByErgoTreeT8Hash.map(_.boxId)).isEmpty,
-        unspentByErgoTreeT8Hash.map(_.boxId).isEmpty,
-        spentByErgoTreeT8Hash.map(_.boxId).isEmpty,
-        spentByErgoTreeT8Hash.size + unspentByErgoTreeT8Hash.size == anyByErgoTreeT8Hash.size,
-        unspentIdsByErgoTreeT8Hash.intersect(spentIdsByErgoTreeT8Hash).isEmpty,
-        unspentIdsByErgoTreeT8Hash.isEmpty,
-        spentIdsByErgoTreeT8Hash.isEmpty,
-        spentIdsByErgoTreeT8Hash.size + unspentIdsByErgoTreeT8Hash.size == anyIdsByErgoTreeT8Hash.size
-      )
-    }.provide(
-      H2Backend.zLayerFromConf,
-      PersistentBoxRepo.layer,
-      BoxService.layer,
-      CoreConf.layer
-    ),
-    test("get spent/unspent/any box(es) by address with index filter") {
-      val spentByAddressGet   = Request.get(URL(Root / "boxes" / "spent" / "by-address" / Emission.address).withQueryParams(indexFilter))
-      val unspentByAddressGet = Request.get(URL(Root / "boxes" / "unspent" / "by-address" / Emission.address).withQueryParams(indexFilter))
-      val anyByAddressGet     = Request.get(URL(Root / "boxes" / "any" / "by-address" / Emission.address).withQueryParams(indexFilter))
+        val spentByErgoTreeT8Get =
+          Request.get(URL(Root / rootPath / "boxes" / "spent" / "templates" / "by-ergo-tree" / Emission.ergoTreeHex).withQueryParams(indexFilter))
+        val unspentByErgoTreeT8Get =
+          Request.get(URL(Root / rootPath / "boxes" / "unspent" / "templates" / "by-ergo-tree" / Emission.ergoTreeHex).withQueryParams(indexFilter))
+        val anyByErgoTreeT8Get =
+          Request.get(URL(Root / rootPath / "boxes" / "any" / "templates" / "by-ergo-tree" / Emission.ergoTreeHex).withQueryParams(indexFilter))
 
-      val spentIdsByAddressGet   = Request.get(URL(Root / "box-ids" / "spent" / "by-address" / Emission.address).withQueryParams(indexFilter))
-      val unspentIdsByAddressGet = Request.get(URL(Root / "box-ids" / "unspent" / "by-address" / Emission.address).withQueryParams(indexFilter))
-      val anyIdsByAddressGet     = Request.get(URL(Root / "box-ids" / "any" / "by-address" / Emission.address).withQueryParams(indexFilter))
+        val spentIdsByErgoTreeT8Get =
+          Request.get(URL(Root / rootPath / "box-ids" / "spent" / "templates" / "by-ergo-tree" / Emission.ergoTreeHex).withQueryParams(indexFilter))
+        val unspentIdsByErgoTreeT8Get =
+          Request.get(URL(Root / rootPath / "box-ids" / "unspent" / "templates" / "by-ergo-tree" / Emission.ergoTreeHex).withQueryParams(indexFilter))
+        val anyIdsByErgoTreeT8Get =
+          Request.get(URL(Root / rootPath / "box-ids" / "any" / "templates" / "by-ergo-tree" / Emission.ergoTreeHex).withQueryParams(indexFilter))
 
-      for {
-        spentByAddress      <- boxRoutes.runZIO(spentByAddressGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
-        unspentByAddress    <- boxRoutes.runZIO(unspentByAddressGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Utxo]])))
-        anyByAddress        <- boxRoutes.runZIO(anyByAddressGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
-        spentIdsByAddress   <- boxRoutes.runZIO(spentIdsByAddressGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
-        unspentIdsByAddress <- boxRoutes.runZIO(unspentIdsByAddressGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
-        anyIdsByAddress     <- boxRoutes.runZIO(anyIdsByAddressGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
-      } yield assertTrue(
-        unspentByAddress.map(_.boxId).intersect(spentByAddress.map(_.boxId)).isEmpty,
-        unspentByAddress.map(_.boxId).isEmpty,
-        spentByAddress.map(_.boxId).isEmpty,
-        spentByAddress.size + unspentByAddress.size == anyByAddress.size,
-        unspentIdsByAddress.intersect(spentIdsByAddress).isEmpty,
-        unspentIdsByAddress.isEmpty,
-        spentIdsByAddress.isEmpty,
-        spentIdsByAddress.size + unspentIdsByAddress.size == anyIdsByAddress.size
-      )
-    }.provide(
-      H2Backend.zLayerFromConf,
-      PersistentBoxRepo.layer,
-      BoxService.layer,
-      CoreConf.layer
-    ),
-    test("get spent/unspent/any box contracts by ergo-tree with index filter") {
-      val spentByErgoTreeGet   = Request.get(URL(Root / "boxes" / "spent" / "contracts" / "by-ergo-tree" / Emission.ergoTreeHex).withQueryParams(indexFilter))
-      val unspentByErgoTreeGet = Request.get(URL(Root / "boxes" / "unspent" / "contracts" / "by-ergo-tree" / Emission.ergoTreeHex).withQueryParams(indexFilter))
-      val anyByErgoTreeGet     = Request.get(URL(Root / "boxes" / "any" / "contracts" / "by-ergo-tree" / Emission.ergoTreeHex).withQueryParams(indexFilter))
+        for {
+          spentByErgoTreeT8 <- routes.runZIO(spentByErgoTreeT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
+          unspentByErgoTreeT8 <-
+            routes.runZIO(unspentByErgoTreeT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Utxo]])))
+          anyByErgoTreeT8 <- routes.runZIO(anyByErgoTreeT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
+          spentIdsByErgoTreeT8 <-
+            routes.runZIO(spentIdsByErgoTreeT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
+          unspentIdsByErgoTreeT8 <-
+            routes.runZIO(unspentIdsByErgoTreeT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
+          anyIdsByErgoTreeT8 <-
+            routes.runZIO(anyIdsByErgoTreeT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
+        } yield assertTrue(
+          unspentByErgoTreeT8.map(_.boxId).intersect(spentByErgoTreeT8.map(_.boxId)).isEmpty,
+          unspentByErgoTreeT8.map(_.boxId).isEmpty,
+          spentByErgoTreeT8.map(_.boxId).isEmpty,
+          spentByErgoTreeT8.size + unspentByErgoTreeT8.size == anyByErgoTreeT8.size,
+          unspentIdsByErgoTreeT8.intersect(spentIdsByErgoTreeT8).isEmpty,
+          unspentIdsByErgoTreeT8.isEmpty,
+          spentIdsByErgoTreeT8.isEmpty,
+          spentIdsByErgoTreeT8.size + unspentIdsByErgoTreeT8.size == anyIdsByErgoTreeT8.size
+        )
+      },
+      test("get spent/unspent/any box contracts by ergo-tree-hash with index filter") {
+        val spentByErgoTreeHashGet =
+          Request.get(URL(Root / rootPath / "boxes" / "spent" / "contracts" / "by-ergo-tree-hash" / Emission.ergoTreeHash).withQueryParams(indexFilter))
+        val unspentByErgoTreeHashGet =
+          Request.get(URL(Root / rootPath / "boxes" / "unspent" / "contracts" / "by-ergo-tree-hash" / Emission.ergoTreeHash).withQueryParams(indexFilter))
+        val anyByErgoTreeHashGet =
+          Request.get(URL(Root / rootPath / "boxes" / "any" / "contracts" / "by-ergo-tree-hash" / Emission.ergoTreeHash).withQueryParams(indexFilter))
 
-      val spentIdsByErgoTreeGet =
-        Request.get(URL(Root / "box-ids" / "spent" / "contracts" / "by-ergo-tree" / Emission.ergoTreeHex).withQueryParams(indexFilter))
-      val unspentIdsByErgoTreeGet =
-        Request.get(URL(Root / "box-ids" / "unspent" / "contracts" / "by-ergo-tree" / Emission.ergoTreeHex).withQueryParams(indexFilter))
-      val anyIdsByErgoTreeGet = Request.get(URL(Root / "boxes" / "any" / "contracts" / "by-ergo-tree" / Emission.ergoTreeHex).withQueryParams(indexFilter))
+        val spentIdsByErgoTreeHashGet =
+          Request.get(URL(Root / rootPath / "box-ids" / "spent" / "contracts" / "by-ergo-tree-hash" / Emission.ergoTreeHash).withQueryParams(indexFilter))
+        val unspentIdsByErgoTreeHashGet =
+          Request.get(URL(Root / rootPath / "box-ids" / "unspent" / "contracts" / "by-ergo-tree-hash" / Emission.ergoTreeHash).withQueryParams(indexFilter))
+        val anyIdsByErgoTreeHashGet =
+          Request.get(URL(Root / rootPath / "box-ids" / "any" / "contracts" / "by-ergo-tree-hash" / Emission.ergoTreeHash).withQueryParams(indexFilter))
 
-      for {
-        spentByErgoTree      <- boxRoutes.runZIO(spentByErgoTreeGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
-        unspentByErgoTree    <- boxRoutes.runZIO(unspentByErgoTreeGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Utxo]])))
-        anyByErgoTree        <- boxRoutes.runZIO(anyByErgoTreeGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
-        spentIdsByErgoTree   <- boxRoutes.runZIO(spentIdsByErgoTreeGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
-        unspentIdsByErgoTree <- boxRoutes.runZIO(unspentIdsByErgoTreeGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
-        anyIdsByErgoTree     <- boxRoutes.runZIO(anyIdsByErgoTreeGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
-      } yield assertTrue(
-        unspentByErgoTree.map(_.boxId).intersect(spentByErgoTree.map(_.boxId)).isEmpty,
-        unspentByErgoTree.map(_.boxId).isEmpty,
-        spentByErgoTree.map(_.boxId).isEmpty,
-        spentByErgoTree.size + unspentByErgoTree.size == anyByErgoTree.size,
-        unspentIdsByErgoTree.intersect(spentIdsByErgoTree).isEmpty,
-        unspentIdsByErgoTree.isEmpty,
-        spentIdsByErgoTree.isEmpty,
-        spentIdsByErgoTree.size + unspentIdsByErgoTree.size == anyIdsByErgoTree.size
-      )
-    }.provide(
-      H2Backend.zLayerFromConf,
-      PersistentBoxRepo.layer,
-      BoxService.layer,
-      CoreConf.layer
-    ),
-    test("get spent/unspent/any box templates by ergo-tree with index filter") {
+        for {
+          spentByErgoTreeHash <-
+            routes.runZIO(spentByErgoTreeHashGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
+          unspentByErgoTreeHash <-
+            routes.runZIO(unspentByErgoTreeHashGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Utxo]])))
+          anyByErgoTreeHash <- routes.runZIO(anyByErgoTreeHashGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
+          spentIdsByErgoTreeHash <-
+            routes.runZIO(spentIdsByErgoTreeHashGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
+          unspentIdsByErgoTreeHash <-
+            routes.runZIO(unspentIdsByErgoTreeHashGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
+          anyIdsByErgoTreeHash <-
+            routes.runZIO(anyIdsByErgoTreeHashGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
+        } yield assertTrue(
+          unspentByErgoTreeHash.map(_.boxId).intersect(spentByErgoTreeHash.map(_.boxId)).isEmpty,
+          unspentByErgoTreeHash.map(_.boxId).isEmpty,
+          spentByErgoTreeHash.map(_.boxId).isEmpty,
+          spentByErgoTreeHash.size + unspentByErgoTreeHash.size == anyByErgoTreeHash.size,
+          unspentIdsByErgoTreeHash.intersect(spentIdsByErgoTreeHash).isEmpty,
+          unspentIdsByErgoTreeHash.isEmpty,
+          spentIdsByErgoTreeHash.isEmpty,
+          spentIdsByErgoTreeHash.size + unspentIdsByErgoTreeHash.size == anyIdsByErgoTreeHash.size
+        )
+      },
+      test("get spent/unspent/any box templates by ergo-tree-hash with index filter") {
+        val spentByErgoTreeHashT8Get =
+          Request.get(URL(Root / rootPath / "boxes" / "spent" / "templates" / "by-ergo-tree-hash" / Emission.ergoTreeHash).withQueryParams(indexFilter))
+        val unspentByErgoTreeHashT8Get =
+          Request.get(URL(Root / rootPath / "boxes" / "unspent" / "templates" / "by-ergo-tree-hash" / Emission.ergoTreeHash).withQueryParams(indexFilter))
+        val anyByErgoTreeHashT8Get =
+          Request.get(URL(Root / rootPath / "boxes" / "any" / "templates" / "by-ergo-tree-hash" / Emission.ergoTreeHash).withQueryParams(indexFilter))
 
-      val spentByErgoTreeT8Get = Request.get(URL(Root / "boxes" / "spent" / "templates" / "by-ergo-tree" / Emission.ergoTreeHex).withQueryParams(indexFilter))
-      val unspentByErgoTreeT8Get =
-        Request.get(URL(Root / "boxes" / "unspent" / "templates" / "by-ergo-tree" / Emission.ergoTreeHex).withQueryParams(indexFilter))
-      val anyByErgoTreeT8Get = Request.get(URL(Root / "boxes" / "any" / "templates" / "by-ergo-tree" / Emission.ergoTreeHex).withQueryParams(indexFilter))
+        val spentIdsByErgoTreeHashT8Get =
+          Request.get(URL(Root / rootPath / "box-ids" / "spent" / "templates" / "by-ergo-tree-hash" / Emission.ergoTreeHash).withQueryParams(indexFilter))
+        val unspentIdsByErgoTreeHashT8Get =
+          Request.get(URL(Root / rootPath / "box-ids" / "unspent" / "templates" / "by-ergo-tree-hash" / Emission.ergoTreeHash).withQueryParams(indexFilter))
+        val anyIdsByErgoTreeHashT8Get =
+          Request.get(URL(Root / rootPath / "box-ids" / "any" / "templates" / "by-ergo-tree-hash" / Emission.ergoTreeHash).withQueryParams(indexFilter))
 
-      val spentIdsByErgoTreeT8Get =
-        Request.get(URL(Root / "box-ids" / "spent" / "templates" / "by-ergo-tree" / Emission.ergoTreeHex).withQueryParams(indexFilter))
-      val unspentIdsByErgoTreeT8Get =
-        Request.get(URL(Root / "box-ids" / "unspent" / "templates" / "by-ergo-tree" / Emission.ergoTreeHex).withQueryParams(indexFilter))
-      val anyIdsByErgoTreeT8Get = Request.get(URL(Root / "box-ids" / "any" / "templates" / "by-ergo-tree" / Emission.ergoTreeHex).withQueryParams(indexFilter))
+        for {
+          spentByErgoTreeT8Hash <-
+            routes.runZIO(spentByErgoTreeHashT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
+          unspentByErgoTreeT8Hash <-
+            routes.runZIO(unspentByErgoTreeHashT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Utxo]])))
+          anyByErgoTreeT8Hash <-
+            routes.runZIO(anyByErgoTreeHashT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
+          spentIdsByErgoTreeT8Hash <-
+            routes.runZIO(spentIdsByErgoTreeHashT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
+          unspentIdsByErgoTreeT8Hash <-
+            routes.runZIO(unspentIdsByErgoTreeHashT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
+          anyIdsByErgoTreeT8Hash <-
+            routes.runZIO(anyIdsByErgoTreeHashT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
+        } yield assertTrue(
+          unspentByErgoTreeT8Hash.map(_.boxId).intersect(spentByErgoTreeT8Hash.map(_.boxId)).isEmpty,
+          unspentByErgoTreeT8Hash.map(_.boxId).isEmpty,
+          spentByErgoTreeT8Hash.map(_.boxId).isEmpty,
+          spentByErgoTreeT8Hash.size + unspentByErgoTreeT8Hash.size == anyByErgoTreeT8Hash.size,
+          unspentIdsByErgoTreeT8Hash.intersect(spentIdsByErgoTreeT8Hash).isEmpty,
+          unspentIdsByErgoTreeT8Hash.isEmpty,
+          spentIdsByErgoTreeT8Hash.isEmpty,
+          spentIdsByErgoTreeT8Hash.size + unspentIdsByErgoTreeT8Hash.size == anyIdsByErgoTreeT8Hash.size
+        )
+      },
+      test("get assets and boxes by tokenId") {
+        val unspentAssetsByTokenIdGet = Request.get(URL(Root / rootPath / "assets" / "unspent" / "by-token-id" / Protocol.firstBlockRewardBox.unwrapped))
+        val spentAssetsByTokenIdGet   = Request.get(URL(Root / rootPath / "assets" / "spent" / "by-token-id" / Protocol.firstBlockRewardBox.unwrapped))
+        val anyAssetsByTokenIdGet     = Request.get(URL(Root / rootPath / "assets" / "any" / "by-token-id" / Protocol.firstBlockRewardBox.unwrapped))
 
-      for {
-        spentByErgoTreeT8      <- boxRoutes.runZIO(spentByErgoTreeT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
-        unspentByErgoTreeT8    <- boxRoutes.runZIO(unspentByErgoTreeT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Utxo]])))
-        anyByErgoTreeT8        <- boxRoutes.runZIO(anyByErgoTreeT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
-        spentIdsByErgoTreeT8   <- boxRoutes.runZIO(spentIdsByErgoTreeT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
-        unspentIdsByErgoTreeT8 <- boxRoutes.runZIO(unspentIdsByErgoTreeT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
-        anyIdsByErgoTreeT8     <- boxRoutes.runZIO(anyIdsByErgoTreeT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
-      } yield assertTrue(
-        unspentByErgoTreeT8.map(_.boxId).intersect(spentByErgoTreeT8.map(_.boxId)).isEmpty,
-        unspentByErgoTreeT8.map(_.boxId).isEmpty,
-        spentByErgoTreeT8.map(_.boxId).isEmpty,
-        spentByErgoTreeT8.size + unspentByErgoTreeT8.size == anyByErgoTreeT8.size,
-        unspentIdsByErgoTreeT8.intersect(spentIdsByErgoTreeT8).isEmpty,
-        unspentIdsByErgoTreeT8.isEmpty,
-        spentIdsByErgoTreeT8.isEmpty,
-        spentIdsByErgoTreeT8.size + unspentIdsByErgoTreeT8.size == anyIdsByErgoTreeT8.size
-      )
-    }.provide(
-      H2Backend.zLayerFromConf,
-      PersistentBoxRepo.layer,
-      BoxService.layer,
-      CoreConf.layer
-    ),
-    test("get spent/unspent/any box contracts by ergo-tree-hash with index filter") {
-      val spentByErgoTreeHashGet =
-        Request.get(URL(Root / "boxes" / "spent" / "contracts" / "by-ergo-tree-hash" / Emission.ergoTreeHash).withQueryParams(indexFilter))
-      val unspentByErgoTreeHashGet =
-        Request.get(URL(Root / "boxes" / "unspent" / "contracts" / "by-ergo-tree-hash" / Emission.ergoTreeHash).withQueryParams(indexFilter))
-      val anyByErgoTreeHashGet =
-        Request.get(URL(Root / "boxes" / "any" / "contracts" / "by-ergo-tree-hash" / Emission.ergoTreeHash).withQueryParams(indexFilter))
+        val unspentBoxesByTokenIdGet  = Request.get(URL(Root / rootPath / "boxes" / "unspent" / "by-token-id" / Protocol.firstBlockRewardBox.unwrapped))
+        val unspentBoxIdsByTokenIdGet = Request.get(URL(Root / rootPath / "box-ids" / "unspent" / "by-token-id" / Protocol.firstBlockRewardBox.unwrapped))
+        val spentBoxesByTokenIdGet    = Request.get(URL(Root / rootPath / "boxes" / "spent" / "by-token-id" / Protocol.firstBlockRewardBox.unwrapped))
+        val spentBoxIdsByTokenIdGet   = Request.get(URL(Root / rootPath / "box-ids" / "spent" / "by-token-id" / Protocol.firstBlockRewardBox.unwrapped))
+        val anyBoxesByTokenIdGet      = Request.get(URL(Root / rootPath / "boxes" / "any" / "by-token-id" / Protocol.firstBlockRewardBox.unwrapped))
+        val anyBoxIdsByTokenIdGet     = Request.get(URL(Root / rootPath / "box-ids" / "any" / "by-token-id" / Protocol.firstBlockRewardBox.unwrapped))
 
-      val spentIdsByErgoTreeHashGet =
-        Request.get(URL(Root / "box-ids" / "spent" / "contracts" / "by-ergo-tree-hash" / Emission.ergoTreeHash).withQueryParams(indexFilter))
-      val unspentIdsByErgoTreeHashGet =
-        Request.get(URL(Root / "box-ids" / "unspent" / "contracts" / "by-ergo-tree-hash" / Emission.ergoTreeHash).withQueryParams(indexFilter))
-      val anyIdsByErgoTreeHashGet =
-        Request.get(URL(Root / "box-ids" / "any" / "contracts" / "by-ergo-tree-hash" / Emission.ergoTreeHash).withQueryParams(indexFilter))
-
-      for {
-        spentByErgoTreeHash      <- boxRoutes.runZIO(spentByErgoTreeHashGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
-        unspentByErgoTreeHash    <- boxRoutes.runZIO(unspentByErgoTreeHashGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Utxo]])))
-        anyByErgoTreeHash        <- boxRoutes.runZIO(anyByErgoTreeHashGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
-        spentIdsByErgoTreeHash   <- boxRoutes.runZIO(spentIdsByErgoTreeHashGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
-        unspentIdsByErgoTreeHash <- boxRoutes.runZIO(unspentIdsByErgoTreeHashGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
-        anyIdsByErgoTreeHash     <- boxRoutes.runZIO(anyIdsByErgoTreeHashGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
-      } yield assertTrue(
-        unspentByErgoTreeHash.map(_.boxId).intersect(spentByErgoTreeHash.map(_.boxId)).isEmpty,
-        unspentByErgoTreeHash.map(_.boxId).isEmpty,
-        spentByErgoTreeHash.map(_.boxId).isEmpty,
-        spentByErgoTreeHash.size + unspentByErgoTreeHash.size == anyByErgoTreeHash.size,
-        unspentIdsByErgoTreeHash.intersect(spentIdsByErgoTreeHash).isEmpty,
-        unspentIdsByErgoTreeHash.isEmpty,
-        spentIdsByErgoTreeHash.isEmpty,
-        spentIdsByErgoTreeHash.size + unspentIdsByErgoTreeHash.size == anyIdsByErgoTreeHash.size
-      )
-    }.provide(
-      H2Backend.zLayerFromConf,
-      PersistentBoxRepo.layer,
-      BoxService.layer,
-      CoreConf.layer
-    ),
-    test("get spent/unspent/any box templates by ergo-tree-hash with index filter") {
-      val spentByErgoTreeHashT8Get =
-        Request.get(URL(Root / "boxes" / "spent" / "templates" / "by-ergo-tree-hash" / Emission.ergoTreeHash).withQueryParams(indexFilter))
-      val unspentByErgoTreeHashT8Get =
-        Request.get(URL(Root / "boxes" / "unspent" / "templates" / "by-ergo-tree-hash" / Emission.ergoTreeHash).withQueryParams(indexFilter))
-      val anyByErgoTreeHashT8Get =
-        Request.get(URL(Root / "boxes" / "any" / "templates" / "by-ergo-tree-hash" / Emission.ergoTreeHash).withQueryParams(indexFilter))
-
-      val spentIdsByErgoTreeHashT8Get =
-        Request.get(URL(Root / "box-ids" / "spent" / "templates" / "by-ergo-tree-hash" / Emission.ergoTreeHash).withQueryParams(indexFilter))
-      val unspentIdsByErgoTreeHashT8Get =
-        Request.get(URL(Root / "box-ids" / "unspent" / "templates" / "by-ergo-tree-hash" / Emission.ergoTreeHash).withQueryParams(indexFilter))
-      val anyIdsByErgoTreeHashT8Get =
-        Request.get(URL(Root / "box-ids" / "any" / "templates" / "by-ergo-tree-hash" / Emission.ergoTreeHash).withQueryParams(indexFilter))
-
-      for {
-        spentByErgoTreeT8Hash    <- boxRoutes.runZIO(spentByErgoTreeHashT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
-        unspentByErgoTreeT8Hash  <- boxRoutes.runZIO(unspentByErgoTreeHashT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Utxo]])))
-        anyByErgoTreeT8Hash      <- boxRoutes.runZIO(anyByErgoTreeHashT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Box]])))
-        spentIdsByErgoTreeT8Hash <- boxRoutes.runZIO(spentIdsByErgoTreeHashT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
-        unspentIdsByErgoTreeT8Hash <-
-          boxRoutes.runZIO(unspentIdsByErgoTreeHashT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
-        anyIdsByErgoTreeT8Hash <- boxRoutes.runZIO(anyIdsByErgoTreeHashT8Get).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
-      } yield assertTrue(
-        unspentByErgoTreeT8Hash.map(_.boxId).intersect(spentByErgoTreeT8Hash.map(_.boxId)).isEmpty,
-        unspentByErgoTreeT8Hash.map(_.boxId).isEmpty,
-        spentByErgoTreeT8Hash.map(_.boxId).isEmpty,
-        spentByErgoTreeT8Hash.size + unspentByErgoTreeT8Hash.size == anyByErgoTreeT8Hash.size,
-        unspentIdsByErgoTreeT8Hash.intersect(spentIdsByErgoTreeT8Hash).isEmpty,
-        unspentIdsByErgoTreeT8Hash.isEmpty,
-        spentIdsByErgoTreeT8Hash.isEmpty,
-        spentIdsByErgoTreeT8Hash.size + unspentIdsByErgoTreeT8Hash.size == anyIdsByErgoTreeT8Hash.size
-      )
-    }.provide(
-      H2Backend.zLayerFromConf,
-      PersistentBoxRepo.layer,
-      BoxService.layer,
-      CoreConf.layer
-    ),
-    test("get assets and boxes by tokenId") {
-      val unspentAssetsByTokenIdGet = Request.get(URL(Root / "assets" / "unspent" / "by-token-id" / Protocol.firstBlockRewardBox.unwrapped))
-      val spentAssetsByTokenIdGet   = Request.get(URL(Root / "assets" / "spent" / "by-token-id" / Protocol.firstBlockRewardBox.unwrapped))
-      val anyAssetsByTokenIdGet     = Request.get(URL(Root / "assets" / "any" / "by-token-id" / Protocol.firstBlockRewardBox.unwrapped))
-
-      val unspentBoxesByTokenIdGet  = Request.get(URL(Root / "boxes" / "unspent" / "by-token-id" / Protocol.firstBlockRewardBox.unwrapped))
-      val unspentBoxIdsByTokenIdGet = Request.get(URL(Root / "box-ids" / "unspent" / "by-token-id" / Protocol.firstBlockRewardBox.unwrapped))
-      val spentBoxesByTokenIdGet    = Request.get(URL(Root / "boxes" / "spent" / "by-token-id" / Protocol.firstBlockRewardBox.unwrapped))
-      val spentBoxIdsByTokenIdGet   = Request.get(URL(Root / "box-ids" / "spent" / "by-token-id" / Protocol.firstBlockRewardBox.unwrapped))
-      val anyBoxesByTokenIdGet      = Request.get(URL(Root / "boxes" / "any" / "by-token-id" / Protocol.firstBlockRewardBox.unwrapped))
-      val anyBoxIdsByTokenIdGet     = Request.get(URL(Root / "box-ids" / "any" / "by-token-id" / Protocol.firstBlockRewardBox.unwrapped))
-
-      for {
-        unspentAssets <- boxRoutes.runZIO(unspentAssetsByTokenIdGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Asset]])))
-        spentAssets   <- boxRoutes.runZIO(spentAssetsByTokenIdGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Asset]])))
-        anyAssets     <- boxRoutes.runZIO(anyAssetsByTokenIdGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Asset]])))
-        unspentBoxes  <- boxRoutes.runZIO(unspentBoxesByTokenIdGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Asset]])))
-        unspentBoxIds <- boxRoutes.runZIO(unspentBoxIdsByTokenIdGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
-        spentBoxes    <- boxRoutes.runZIO(spentBoxesByTokenIdGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Asset]])))
-        spentBoxIds   <- boxRoutes.runZIO(spentBoxIdsByTokenIdGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
-        anyBoxes      <- boxRoutes.runZIO(anyBoxesByTokenIdGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Asset]])))
-        anyBoxIds     <- boxRoutes.runZIO(anyBoxIdsByTokenIdGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
-      } yield assertTrue(
-        unspentAssets.isEmpty,
-        spentAssets.isEmpty,
-        anyAssets.isEmpty,
-        unspentBoxes.isEmpty,
-        unspentBoxIds.isEmpty,
-        spentBoxes.isEmpty,
-        spentBoxIds.isEmpty,
-        anyBoxes.isEmpty,
-        anyBoxIds.isEmpty
-      )
-    }.provide(
-      H2Backend.zLayerFromConf,
-      PersistentBoxRepo.layer,
-      BoxService.layer,
-      CoreConf.layer
-    )
-  )
+        for {
+          unspentAssets <- routes.runZIO(unspentAssetsByTokenIdGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Asset]])))
+          spentAssets   <- routes.runZIO(spentAssetsByTokenIdGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Asset]])))
+          anyAssets     <- routes.runZIO(anyAssetsByTokenIdGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Asset]])))
+          unspentBoxes  <- routes.runZIO(unspentBoxesByTokenIdGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Asset]])))
+          unspentBoxIds <- routes.runZIO(unspentBoxIdsByTokenIdGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
+          spentBoxes    <- routes.runZIO(spentBoxesByTokenIdGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Asset]])))
+          spentBoxIds   <- routes.runZIO(spentBoxIdsByTokenIdGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
+          anyBoxes      <- routes.runZIO(anyBoxesByTokenIdGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[Asset]])))
+          anyBoxIds     <- routes.runZIO(anyBoxIdsByTokenIdGet).flatMap(_.body.asString.flatMap(x => ZIO.fromEither(x.fromJson[List[BoxId]])))
+        } yield assertTrue(
+          unspentAssets.isEmpty,
+          spentAssets.isEmpty,
+          anyAssets.isEmpty,
+          unspentBoxes.isEmpty,
+          unspentBoxIds.isEmpty,
+          spentBoxes.isEmpty,
+          spentBoxIds.isEmpty,
+          anyBoxes.isEmpty,
+          anyBoxIds.isEmpty
+        )
+      }
+    ).provide(routeLayers)
 }

--- a/modules/chain-indexer/src/main/scala/org/ergoplatform/uexplorer/indexer/ChainIndexer.scala
+++ b/modules/chain-indexer/src/main/scala/org/ergoplatform/uexplorer/indexer/ChainIndexer.scala
@@ -13,6 +13,7 @@ import org.ergoplatform.uexplorer.indexer.mempool.{MemPool, MempoolSyncer}
 import org.ergoplatform.uexplorer.indexer.plugin.PluginManager
 import org.ergoplatform.uexplorer.storage.{MvStorage, MvStoreConf}
 import zio.*
+import zio.http.ZClient
 import zio.logging.LogFormat
 import zio.logging.backend.SLF4J
 
@@ -33,6 +34,7 @@ object ChainIndexer extends ZIOAppDefault {
       NodePoolConf.layer,
       MvStoreConf.layer,
       CoreConf.layer,
+      ZClient.default,
       MemPool.layer,
       NodePool.layer,
       UnderlyingBackend.layer,

--- a/modules/chain-indexer/src/main/scala/org/ergoplatform/uexplorer/indexer/db/Backend.scala
+++ b/modules/chain-indexer/src/main/scala/org/ergoplatform/uexplorer/indexer/db/Backend.scala
@@ -4,14 +4,16 @@ import org.ergoplatform.uexplorer.*
 import org.ergoplatform.uexplorer.backend.H2Backend
 import org.ergoplatform.uexplorer.backend.blocks.{BlockRepo, BlockService}
 import org.ergoplatform.uexplorer.backend.boxes.BoxService
+import org.ergoplatform.uexplorer.http.NodePool
 import org.ergoplatform.uexplorer.indexer.config.{Cassandra, ChainIndexerConf, H2}
 import zio.*
+import zio.http.Client
 
 import javax.sql.DataSource
 
 object Backend {
 
-  def runServer: ZIO[DataSource with BoxService with BlockService with ChainIndexerConf, Throwable, Nothing] =
+  def runServer: ZIO[Client with NodePool with DataSource with BoxService with BlockService with ChainIndexerConf, Throwable, Nothing] =
     ZIO.serviceWithZIO[ChainIndexerConf] { conf =>
       conf.backendType match {
         case Cassandra(parallelism) =>

--- a/modules/explorer-core/src/test/resources/application.conf
+++ b/modules/explorer-core/src/test/resources/application.conf
@@ -10,7 +10,7 @@ uexplorer {
     chainIndexer {
         nodePool {
             nodeAddressToInitFrom = "http://local"
-            peerAddressToPollFrom = "http://remote"
+            peerAddressToPollFrom = "http://213.239.193.208:9053"
         }
 
         mvStore {

--- a/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/multimap/SuperNodeMvMap.scala
+++ b/modules/mvstore/src/main/scala/org/ergoplatform/uexplorer/mvstore/multimap/SuperNodeMvMap.scala
@@ -193,7 +193,7 @@ class SuperNodeMvMap[HK, C[A, B] <: java.util.Map[A, B], K, V](
 
   def mergeCommonMap(implicit vc: ValueCodec[C[K, V]]): Task[MapLike[HK, C[K, V]]] =
     MvMap[HK, C[K, V]](id).tap { commonMap =>
-      ZIO.log(s"Checking if merging ${existingMapsByHotKey.size} hotkeys needs merging at $id") *> ZIO
+      ZIO.log(s"Checking if ${existingMapsByHotKey.size} hotkeys needs merging at $id") *> ZIO
         .attempt {
           superNodeCollector.getStringifiedHotKeys.flatMap { case (hotKey, hotKeyString) =>
             commonMap.get(hotKey).map { values =>

--- a/modules/node-pool/src/main/scala/org/ergoplatform/uexplorer/http/MetadataHttpClient.scala
+++ b/modules/node-pool/src/main/scala/org/ergoplatform/uexplorer/http/MetadataHttpClient.scala
@@ -1,25 +1,16 @@
 package org.ergoplatform.uexplorer.http
 
 import io.circe.Decoder
-import org.ergoplatform.uexplorer.Const.EpochLength
+import nl.vroste.rezilience.*
 import org.ergoplatform.uexplorer.Const
 import sttp.client3.*
 import sttp.client3.circe.asJson
-import zio.stream.ZStream
 import zio.*
-import nl.vroste.rezilience.*
+import zio.stream.ZStream
 
-import scala.concurrent.duration
 import scala.collection.immutable.{SortedSet, TreeSet}
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
-import scala.util.{Failure, Success}
-import nl.vroste.rezilience.Retry.Schedules
-import sttp.capabilities.zio.ZioStreams
-import sttp.client3.httpclient.zio.{HttpClientZioBackend, SttpClient}
-
+import scala.concurrent.duration
 import scala.concurrent.duration.FiniteDuration
-import sttp.model.Uri
 
 case class MetadataHttpClient(underlying: UnderlyingBackend, conf: NodePoolConf) {
 

--- a/modules/node-pool/src/main/scala/org/ergoplatform/uexplorer/http/NodePool.scala
+++ b/modules/node-pool/src/main/scala/org/ergoplatform/uexplorer/http/NodePool.scala
@@ -4,15 +4,13 @@ import org.ergoplatform.uexplorer.http.NodePool.{InvalidPeers, NewPeers}
 import zio.*
 
 import scala.collection.immutable.{SortedSet, TreeSet}
-import scala.concurrent.Future
-import scala.concurrent.duration.DurationInt
 
 case class NodePool(ref: Ref[NodePoolState]) {
   def updateOpenApiPeers(peers: SortedSet[Peer]): UIO[NewPeers] = ref.modify(_.updatePeers(peers))
   def invalidatePeers(peers: InvalidPeers): UIO[InvalidPeers]   = ref.modify(_.invalidatePeers(peers))
-
-  def getAvailablePeers: UIO[SortedSet[Peer]] = ref.get.map(_.openApiPeers)
-  def clean: UIO[Unit]                        = ref.set(NodePoolState.empty)
+  def getBestPeer: UIO[Option[Peer]]                            = getAvailablePeers.map(_.headOption)
+  def getAvailablePeers: UIO[SortedSet[Peer]]                   = ref.get.map(_.openApiPeers)
+  def clean: UIO[Unit]                                          = ref.set(NodePoolState.empty)
 }
 
 object NodePool {
@@ -20,4 +18,10 @@ object NodePool {
   type NewPeers     = SortedSet[Peer]
   type AllPeers     = SortedSet[Peer]
   def layer: ZLayer[Any, Nothing, NodePool] = ZLayer.fromZIO(Ref.make(NodePoolState.empty).map(NodePool(_)))
+
+  def layerInitializedFromConf: ZLayer[NodePoolConf, Nothing, NodePool] =
+    ZLayer.service[NodePoolConf].flatMap { confEnv =>
+      val peer = RemoteNode(confEnv.get.peerAddressToPollFrom, "", "", 1)
+      ZLayer.fromZIO(Ref.make(NodePoolState.empty).map(NodePool(_)).tap(_.updateOpenApiPeers(TreeSet(peer))))
+    }
 }


### PR DESCRIPTION
`/explorer/*` - these are explorer's endpoints
`/*` - everything else is proxied over to best-available Node in this order (local, specified-remote, any-peer)

I made sure that any Node that request is proxied to is fully synchronized as otherwise it would be hard to reason about.