### PR TITLE
Add ARM64 docker build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,6 +13,12 @@ jobs:
         name: Checkout 
         uses: actions/checkout@v2
       -
+        name: Setup QEMU
+        uses: docker/setup-qemu-action@v2
+      - 
+        name: Setup Buildx
+        uses: docker/setup-buildx-action@v2
+      -
         name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -31,5 +37,6 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM mozilla/sbt:11.0.8_1.3.13 as builder
+FROM sbtscala/scala-sbt:eclipse-temurin-11.0.16_1.7.2_3.2.0 as builder
 WORKDIR /mnt
 COPY build.sbt ./
 COPY project/ project/
 COPY modules/chain-indexer/ modules/chain-indexer/
 RUN sbt stage
 
-FROM openjdk:11-jre-slim
+FROM eclipse-temurin:11-jre-jammy
 WORKDIR /uexplorer/chain-indexer
 COPY --from=builder /mnt/modules/chain-indexer/target/universal/stage/ /uexplorer/chain-indexer
 ENTRYPOINT ["/uexplorer/chain-indexer/bin/chain-indexer"]


### PR DESCRIPTION
ARM64 is widely used nowadays, so this PR covers ARM64 users:

- Modify Dockerfile to add sbt image that supports arm64
- Change docker publish GH action to build and publish arm64 image.

Personally, I run eclipse temurin jre everywhere, however, you are welcome to change it if this is not what you prefer.